### PR TITLE
Extract pg/ module (COPY helpers, batching, UNLOGGED)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,8 @@
+[workspace]
+members = ["wxyc-etl", "wxyc-etl-python"]
+resolver = "2"
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "MIT"

--- a/wxyc-etl-python/Cargo.toml
+++ b/wxyc-etl-python/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "wxyc-etl-python"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+name = "wxyc_etl"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.22", features = ["extension-module"] }
+wxyc-etl = { path = "../wxyc-etl" }

--- a/wxyc-etl-python/src/lib.rs
+++ b/wxyc-etl-python/src/lib.rs
@@ -1,0 +1,6 @@
+use pyo3::prelude::*;
+
+#[pymodule]
+fn wxyc_etl(_py: Python, _m: &Bound<'_, PyModule>) -> PyResult<()> {
+    Ok(())
+}

--- a/wxyc-etl/Cargo.toml
+++ b/wxyc-etl/Cargo.toml
@@ -8,7 +8,7 @@ description = "Shared ETL crate for the WXYC music data pipeline"
 [dependencies]
 # text module
 unicode-normalization = "0.1"
-unicode-categories = "0.1"
+unicode_categories = "0.1"
 
 # pg module
 postgres = "0.19"

--- a/wxyc-etl/Cargo.toml
+++ b/wxyc-etl/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "wxyc-etl"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Shared ETL crate for the WXYC music data pipeline"
+
+[dependencies]
+# text module
+unicode-normalization = "0.1"
+unicode-categories = "0.1"
+
+# pg module
+postgres = "0.19"
+itoa = "1"
+
+# pipeline module
+crossbeam-channel = "0.5"
+rayon = "1.10"
+
+# csv module
+csv = "1.3"
+
+# sqlite module
+rusqlite = { version = "0.31", features = ["bundled"] }
+
+# state/import modules
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# fuzzy module
+strsim = "0.11"
+
+# parser module
+memmap2 = "0.9"
+memchr = "2"
+
+# shared
+anyhow = "1"
+log = "0.4"
+env_logger = "0.11"
+
+[dev-dependencies]
+tempfile = "3"

--- a/wxyc-etl/src/csv_writer/mod.rs
+++ b/wxyc-etl/src/csv_writer/mod.rs
@@ -1,0 +1,1 @@
+//! csv_writer module — see implementation plan for details.

--- a/wxyc-etl/src/fuzzy/mod.rs
+++ b/wxyc-etl/src/fuzzy/mod.rs
@@ -1,0 +1,1 @@
+//! fuzzy module — see implementation plan for details.

--- a/wxyc-etl/src/import/mod.rs
+++ b/wxyc-etl/src/import/mod.rs
@@ -1,0 +1,1 @@
+//! import module — see implementation plan for details.

--- a/wxyc-etl/src/lib.rs
+++ b/wxyc-etl/src/lib.rs
@@ -1,0 +1,15 @@
+//! Shared ETL crate for the WXYC music data pipeline.
+//!
+//! Provides text normalization, fuzzy matching, PostgreSQL bulk loading,
+//! pipeline orchestration, and schema contracts.
+
+pub mod text;
+pub mod pg;
+pub mod pipeline;
+pub mod csv_writer;
+pub mod sqlite;
+pub mod state;
+pub mod import;
+pub mod schema;
+pub mod fuzzy;
+pub mod parser;

--- a/wxyc-etl/src/parser/mod.rs
+++ b/wxyc-etl/src/parser/mod.rs
@@ -1,0 +1,1 @@
+//! parser module — see implementation plan for details.

--- a/wxyc-etl/src/pg/admin.rs
+++ b/wxyc-etl/src/pg/admin.rs
@@ -1,0 +1,175 @@
+//! PostgreSQL administrative operations for bulk imports.
+//!
+//! Provides `SET UNLOGGED` / `SET LOGGED` table toggles and `VACUUM FULL`
+//! for optimizing bulk data loading performance.
+
+use anyhow::{Context, Result};
+use log::info;
+
+/// Set tables to UNLOGGED for faster bulk imports (disables WAL).
+///
+/// **Warning**: UNLOGGED tables are not crash-safe. Data will be lost if
+/// the server crashes while tables are in this mode. Always call
+/// [`set_tables_logged()`] after the import completes.
+///
+/// Table names are validated to contain only alphanumeric characters and
+/// underscores to prevent SQL injection.
+pub fn set_tables_unlogged(client: &mut postgres::Client, tables: &[&str]) -> Result<()> {
+    for table in tables {
+        validate_table_name(table)?;
+        let sql = format!("ALTER TABLE {} SET UNLOGGED", table);
+        client
+            .execute(&sql, &[])
+            .with_context(|| format!("failed to set {} UNLOGGED", table))?;
+        info!("Set {} to UNLOGGED", table);
+    }
+    Ok(())
+}
+
+/// Restore tables to LOGGED mode (re-enables WAL durability).
+///
+/// Table names are validated to contain only alphanumeric characters and
+/// underscores to prevent SQL injection.
+pub fn set_tables_logged(client: &mut postgres::Client, tables: &[&str]) -> Result<()> {
+    for table in tables {
+        validate_table_name(table)?;
+        let sql = format!("ALTER TABLE {} SET LOGGED", table);
+        client
+            .execute(&sql, &[])
+            .with_context(|| format!("failed to set {} LOGGED", table))?;
+        info!("Set {} to LOGGED", table);
+    }
+    Ok(())
+}
+
+/// Run `VACUUM FULL` on tables to reclaim space after bulk deletes/updates.
+///
+/// Table names are validated to contain only alphanumeric characters and
+/// underscores to prevent SQL injection.
+pub fn vacuum_full(client: &mut postgres::Client, tables: &[&str]) -> Result<()> {
+    for table in tables {
+        validate_table_name(table)?;
+        let sql = format!("VACUUM FULL {}", table);
+        client
+            .execute(&sql, &[])
+            .with_context(|| format!("failed to VACUUM FULL {}", table))?;
+        info!("VACUUM FULL {}", table);
+    }
+    Ok(())
+}
+
+/// Validate that a table name contains only safe characters (alphanumeric + underscore).
+fn validate_table_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("table name cannot be empty");
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        anyhow::bail!(
+            "table name {:?} contains unsafe characters; only alphanumeric and underscore allowed",
+            name
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_table_name_valid() {
+        assert!(validate_table_name("release").is_ok());
+        assert!(validate_table_name("release_artist").is_ok());
+        assert!(validate_table_name("table123").is_ok());
+    }
+
+    #[test]
+    fn test_validate_table_name_empty() {
+        assert!(validate_table_name("").is_err());
+    }
+
+    #[test]
+    fn test_validate_table_name_injection() {
+        assert!(validate_table_name("release; DROP TABLE release").is_err());
+        assert!(validate_table_name("release--comment").is_err());
+        assert!(validate_table_name("public.release").is_err());
+    }
+
+    /// Helper to get a test DB connection, or skip the test.
+    fn test_db_client() -> Option<postgres::Client> {
+        let url = std::env::var("TEST_DATABASE_URL").ok()?;
+        postgres::Client::connect(&url, postgres::NoTls).ok()
+    }
+
+    #[test]
+    fn test_set_unlogged_and_logged() {
+        let mut client = match test_db_client() {
+            Some(c) => c,
+            None => return, // skip if no DB
+        };
+
+        // Set up a test table
+        client
+            .batch_execute(
+                "DROP TABLE IF EXISTS _pg_admin_test;
+                 CREATE TABLE _pg_admin_test (id integer PRIMARY KEY);",
+            )
+            .unwrap();
+
+        // Set UNLOGGED
+        set_tables_unlogged(&mut client, &["_pg_admin_test"]).unwrap();
+
+        // Verify via pg_class
+        let row = client
+            .query_one(
+                "SELECT relpersistence FROM pg_class WHERE relname = '_pg_admin_test'",
+                &[],
+            )
+            .unwrap();
+        assert_eq!(row.get::<_, i8>(0), b'u' as i8);
+
+        // Set LOGGED
+        set_tables_logged(&mut client, &["_pg_admin_test"]).unwrap();
+
+        let row = client
+            .query_one(
+                "SELECT relpersistence FROM pg_class WHERE relname = '_pg_admin_test'",
+                &[],
+            )
+            .unwrap();
+        assert_eq!(row.get::<_, i8>(0), b'p' as i8);
+
+        // Clean up
+        client
+            .execute("DROP TABLE _pg_admin_test", &[])
+            .unwrap();
+    }
+
+    #[test]
+    fn test_vacuum_full() {
+        let mut client = match test_db_client() {
+            Some(c) => c,
+            None => return, // skip if no DB
+        };
+
+        client
+            .batch_execute(
+                "DROP TABLE IF EXISTS _pg_vacuum_test;
+                 CREATE TABLE _pg_vacuum_test (id integer PRIMARY KEY);
+                 INSERT INTO _pg_vacuum_test VALUES (1), (2), (3);
+                 DELETE FROM _pg_vacuum_test;",
+            )
+            .unwrap();
+
+        // Should not error
+        vacuum_full(&mut client, &["_pg_vacuum_test"]).unwrap();
+
+        // Clean up
+        client
+            .execute("DROP TABLE _pg_vacuum_test", &[])
+            .unwrap();
+    }
+}

--- a/wxyc-etl/src/pg/batch.rs
+++ b/wxyc-etl/src/pg/batch.rs
@@ -1,0 +1,307 @@
+//! Buffered COPY with FK-ordered flush.
+//!
+//! [`BatchCopier`] manages multiple per-table byte buffers and flushes them
+//! in a specified order (FK parent before children) when a batch threshold
+//! is reached.
+
+use std::collections::HashMap;
+use std::io::Write;
+
+use anyhow::Result;
+use log::info;
+
+/// Trait abstracting the `COPY ... FROM STDIN` operation.
+///
+/// Implement this for a real PostgreSQL connection or use the test mock.
+pub trait CopyTarget {
+    /// Execute a COPY operation, writing `data` into the table specified by `stmt`.
+    ///
+    /// `stmt` is a full COPY statement like `COPY release (id, title) FROM STDIN`.
+    fn copy_in(&mut self, stmt: &str, data: &[u8]) -> Result<()>;
+}
+
+/// Implementation of [`CopyTarget`] for a real PostgreSQL connection.
+impl CopyTarget for postgres::Client {
+    fn copy_in(&mut self, stmt: &str, data: &[u8]) -> Result<()> {
+        let mut writer = self.copy_in(stmt)?;
+        writer.write_all(data)?;
+        writer.finish()?;
+        Ok(())
+    }
+}
+
+/// A named byte buffer for one table's COPY data.
+pub struct CopyBuffer {
+    /// The full COPY statement (e.g., `COPY release (id, title) FROM STDIN`).
+    pub stmt: String,
+    /// Accumulated COPY TEXT data.
+    pub data: Vec<u8>,
+}
+
+impl CopyBuffer {
+    pub fn new(stmt: impl Into<String>) -> Self {
+        Self {
+            stmt: stmt.into(),
+            data: Vec::new(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
+/// Manages multiple [`CopyBuffer`]s and flushes them in FK-safe order.
+///
+/// Tables are flushed in the order they were registered (parent tables
+/// should be registered before child tables).
+pub struct BatchCopier {
+    /// Table names in flush order (FK parent first).
+    table_order: Vec<String>,
+    /// Per-table buffers, keyed by table name.
+    buffers: HashMap<String, CopyBuffer>,
+    /// Number of records buffered since last flush.
+    batch_count: usize,
+    /// Flush threshold.
+    batch_size: usize,
+    /// Total records flushed.
+    total_written: usize,
+}
+
+impl BatchCopier {
+    /// Create a new `BatchCopier` with the given table names (in FK order)
+    /// and their COPY statements.
+    ///
+    /// `tables` is a slice of `(table_name, copy_stmt)` pairs. Tables are
+    /// flushed in the order provided.
+    pub fn new(tables: &[(&str, &str)], batch_size: usize) -> Self {
+        let table_order: Vec<String> = tables.iter().map(|(name, _)| name.to_string()).collect();
+        let buffers: HashMap<String, CopyBuffer> = tables
+            .iter()
+            .map(|(name, stmt)| (name.to_string(), CopyBuffer::new(*stmt)))
+            .collect();
+        Self {
+            table_order,
+            buffers,
+            batch_count: 0,
+            batch_size,
+            total_written: 0,
+        }
+    }
+
+    /// Get a mutable reference to a table's data buffer for writing COPY rows.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `table` was not registered in [`BatchCopier::new()`].
+    pub fn buffer(&mut self, table: &str) -> &mut Vec<u8> {
+        &mut self
+            .buffers
+            .get_mut(table)
+            .unwrap_or_else(|| panic!("unknown table: {}", table))
+            .data
+    }
+
+    /// Increment the batch counter and flush if the threshold is reached.
+    pub fn count_and_maybe_flush(&mut self, target: &mut impl CopyTarget) -> Result<()> {
+        self.batch_count += 1;
+        if self.batch_count >= self.batch_size {
+            self.flush(target)?;
+        }
+        Ok(())
+    }
+
+    /// Flush all buffers to the target in FK order. No-op if nothing is buffered.
+    pub fn flush(&mut self, target: &mut impl CopyTarget) -> Result<()> {
+        if self.batch_count == 0 {
+            return Ok(());
+        }
+
+        for table_name in &self.table_order {
+            let buf = self.buffers.get_mut(table_name).unwrap();
+            if !buf.is_empty() {
+                target.copy_in(&buf.stmt, &buf.data)?;
+                buf.data.clear();
+            }
+        }
+
+        self.total_written += self.batch_count;
+        info!(
+            "Flushed {} records ({} total)",
+            self.batch_count, self.total_written
+        );
+        self.batch_count = 0;
+
+        Ok(())
+    }
+
+    /// Number of records flushed so far (not counting current unflushed batch).
+    pub fn total_written(&self) -> usize {
+        self.total_written
+    }
+
+    /// Number of records in the current unflushed batch.
+    pub fn batch_count(&self) -> usize {
+        self.batch_count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mock [`CopyTarget`] that records operations in order.
+    struct MockCopyTarget {
+        operations: Vec<(String, Vec<u8>)>,
+    }
+
+    impl MockCopyTarget {
+        fn new() -> Self {
+            Self {
+                operations: Vec::new(),
+            }
+        }
+    }
+
+    impl CopyTarget for MockCopyTarget {
+        fn copy_in(&mut self, stmt: &str, data: &[u8]) -> Result<()> {
+            self.operations.push((stmt.to_string(), data.to_vec()));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_flush_order() {
+        let mut copier = BatchCopier::new(
+            &[
+                ("release", "COPY release FROM STDIN"),
+                ("release_artist", "COPY release_artist FROM STDIN"),
+                ("release_label", "COPY release_label FROM STDIN"),
+            ],
+            100,
+        );
+
+        // Write to child tables first, then parent
+        copier
+            .buffer("release_artist")
+            .extend_from_slice(b"child data\n");
+        copier
+            .buffer("release")
+            .extend_from_slice(b"parent data\n");
+        copier.batch_count = 1; // simulate one record
+
+        let mut target = MockCopyTarget::new();
+        copier.flush(&mut target).unwrap();
+
+        // Parent should be flushed first regardless of write order
+        assert_eq!(target.operations.len(), 2);
+        assert_eq!(target.operations[0].0, "COPY release FROM STDIN");
+        assert_eq!(target.operations[0].1, b"parent data\n");
+        assert_eq!(target.operations[1].0, "COPY release_artist FROM STDIN");
+        assert_eq!(target.operations[1].1, b"child data\n");
+    }
+
+    #[test]
+    fn test_flush_skips_empty_buffers() {
+        let mut copier = BatchCopier::new(
+            &[
+                ("release", "COPY release FROM STDIN"),
+                ("release_artist", "COPY release_artist FROM STDIN"),
+            ],
+            100,
+        );
+
+        // Only write to release, not release_artist
+        copier
+            .buffer("release")
+            .extend_from_slice(b"data\n");
+        copier.batch_count = 1;
+
+        let mut target = MockCopyTarget::new();
+        copier.flush(&mut target).unwrap();
+
+        assert_eq!(target.operations.len(), 1);
+        assert_eq!(target.operations[0].0, "COPY release FROM STDIN");
+    }
+
+    #[test]
+    fn test_flush_noop_when_empty() {
+        let mut copier = BatchCopier::new(
+            &[("release", "COPY release FROM STDIN")],
+            100,
+        );
+
+        let mut target = MockCopyTarget::new();
+        copier.flush(&mut target).unwrap();
+
+        assert!(target.operations.is_empty());
+    }
+
+    #[test]
+    fn test_count_and_maybe_flush() {
+        let mut copier = BatchCopier::new(
+            &[("release", "COPY release FROM STDIN")],
+            2,
+        );
+
+        let mut target = MockCopyTarget::new();
+
+        copier.buffer("release").extend_from_slice(b"row1\n");
+        copier.count_and_maybe_flush(&mut target).unwrap();
+        assert_eq!(copier.total_written(), 0); // not yet at threshold
+
+        copier.buffer("release").extend_from_slice(b"row2\n");
+        copier.count_and_maybe_flush(&mut target).unwrap();
+        assert_eq!(copier.total_written(), 2); // flushed at threshold
+
+        assert_eq!(target.operations.len(), 1);
+        assert_eq!(target.operations[0].1, b"row1\nrow2\n");
+    }
+
+    #[test]
+    fn test_total_written_accumulates() {
+        let mut copier = BatchCopier::new(
+            &[("release", "COPY release FROM STDIN")],
+            1,
+        );
+
+        let mut target = MockCopyTarget::new();
+
+        for i in 0..5 {
+            copier
+                .buffer("release")
+                .extend_from_slice(format!("row{}\n", i).as_bytes());
+            copier.count_and_maybe_flush(&mut target).unwrap();
+        }
+
+        assert_eq!(copier.total_written(), 5);
+        assert_eq!(target.operations.len(), 5);
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown table")]
+    fn test_buffer_panics_on_unknown_table() {
+        let mut copier = BatchCopier::new(
+            &[("release", "COPY release FROM STDIN")],
+            100,
+        );
+        copier.buffer("nonexistent");
+    }
+
+    #[test]
+    fn test_buffers_cleared_after_flush() {
+        let mut copier = BatchCopier::new(
+            &[("release", "COPY release FROM STDIN")],
+            1,
+        );
+
+        let mut target = MockCopyTarget::new();
+
+        copier.buffer("release").extend_from_slice(b"row1\n");
+        copier.count_and_maybe_flush(&mut target).unwrap();
+
+        // Buffer should be cleared after flush
+        assert!(copier.buffer("release").is_empty());
+        assert_eq!(copier.batch_count(), 0);
+    }
+}

--- a/wxyc-etl/src/pg/copy.rs
+++ b/wxyc-etl/src/pg/copy.rs
@@ -1,0 +1,112 @@
+//! PostgreSQL COPY TEXT escaping and row formatting.
+//!
+//! These functions produce data in PostgreSQL's COPY TEXT format:
+//! tab-delimited columns, backslash escaping, and `\N` for NULLs.
+
+/// Escape a string for PostgreSQL COPY TEXT format.
+///
+/// COPY TEXT uses tab-delimited rows with backslash escaping:
+/// - `\` -> `\\`
+/// - newline -> `\n`
+/// - carriage return -> `\r`
+/// - tab -> `\t`
+pub fn escape_copy_text(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Escape a string for PostgreSQL COPY TEXT format, appending directly to a byte buffer.
+///
+/// This is the zero-allocation counterpart of [`escape_copy_text()`]. Instead of
+/// returning a new `String`, it pushes escaped bytes directly into `buf`.
+pub fn escape_copy_text_into(buf: &mut Vec<u8>, s: &str) {
+    for &b in s.as_bytes() {
+        match b {
+            b'\\' => buf.extend_from_slice(b"\\\\"),
+            b'\n' => buf.extend_from_slice(b"\\n"),
+            b'\r' => buf.extend_from_slice(b"\\r"),
+            b'\t' => buf.extend_from_slice(b"\\t"),
+            _ => buf.push(b),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- escape_copy_text tests --
+
+    #[test]
+    fn test_escape_backslash() {
+        assert_eq!(escape_copy_text("a\\b"), "a\\\\b");
+    }
+
+    #[test]
+    fn test_escape_newline() {
+        assert_eq!(escape_copy_text("line1\nline2"), "line1\\nline2");
+    }
+
+    #[test]
+    fn test_escape_tab() {
+        assert_eq!(escape_copy_text("col1\tcol2"), "col1\\tcol2");
+    }
+
+    #[test]
+    fn test_escape_cr() {
+        assert_eq!(escape_copy_text("a\rb"), "a\\rb");
+    }
+
+    #[test]
+    fn test_escape_no_special() {
+        assert_eq!(escape_copy_text("plain text"), "plain text");
+    }
+
+    #[test]
+    fn test_escape_mixed() {
+        assert_eq!(
+            escape_copy_text("line1\nline2\ttab\\slash"),
+            "line1\\nline2\\ttab\\\\slash"
+        );
+    }
+
+    // -- escape_copy_text_into tests --
+
+    #[test]
+    fn test_escape_into_plain() {
+        let mut buf = Vec::new();
+        escape_copy_text_into(&mut buf, "hello world");
+        assert_eq!(buf, b"hello world");
+    }
+
+    #[test]
+    fn test_escape_into_special_chars() {
+        let mut buf = Vec::new();
+        escape_copy_text_into(&mut buf, "line1\nline2\ttab\\slash\rret");
+        assert_eq!(buf, b"line1\\nline2\\ttab\\\\slash\\rret");
+    }
+
+    #[test]
+    fn test_escape_into_matches_escape_copy_text() {
+        let cases = ["hello", "a\tb", "a\nb", "a\\b", "a\rb", "mix\t\n\\end"];
+        for s in &cases {
+            let mut buf = Vec::new();
+            escape_copy_text_into(&mut buf, s);
+            assert_eq!(
+                String::from_utf8(buf).unwrap(),
+                escape_copy_text(s),
+                "Mismatch for input: {:?}",
+                s,
+            );
+        }
+    }
+}

--- a/wxyc-etl/src/pg/copy.rs
+++ b/wxyc-etl/src/pg/copy.rs
@@ -40,6 +40,49 @@ pub fn escape_copy_text_into(buf: &mut Vec<u8>, s: &str) {
     }
 }
 
+/// Format a value for a COPY TEXT column.
+///
+/// `None` and empty strings become `\N` (PostgreSQL NULL).
+/// Non-empty strings are escaped.
+pub fn copy_value(val: Option<&str>) -> String {
+    match val {
+        None | Some("") => "\\N".to_string(),
+        Some(s) => escape_copy_text(s),
+    }
+}
+
+/// Format a COPY TEXT row from a slice of column values.
+///
+/// Joins values with tabs and appends a newline.
+pub fn copy_line(values: &[Option<&str>]) -> String {
+    let mut line = String::new();
+    for (i, val) in values.iter().enumerate() {
+        if i > 0 {
+            line.push('\t');
+        }
+        line.push_str(&copy_value(*val));
+    }
+    line.push('\n');
+    line
+}
+
+/// Write a COPY TEXT row directly into a byte buffer.
+///
+/// This is the zero-allocation counterpart of [`copy_line()`]. Values are
+/// tab-separated; `None` and empty strings become `\N` (PostgreSQL NULL).
+pub fn write_copy_row(buf: &mut Vec<u8>, values: &[Option<&str>]) {
+    for (i, val) in values.iter().enumerate() {
+        if i > 0 {
+            buf.push(b'\t');
+        }
+        match val {
+            None | Some("") => buf.extend_from_slice(b"\\N"),
+            Some(s) => escape_copy_text_into(buf, s),
+        }
+    }
+    buf.push(b'\n');
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -106,6 +149,108 @@ mod tests {
                 escape_copy_text(s),
                 "Mismatch for input: {:?}",
                 s,
+            );
+        }
+    }
+
+    // -- copy_value tests --
+
+    #[test]
+    fn test_copy_value_none() {
+        assert_eq!(copy_value(None), "\\N");
+    }
+
+    #[test]
+    fn test_copy_value_empty() {
+        assert_eq!(copy_value(Some("")), "\\N");
+    }
+
+    #[test]
+    fn test_copy_value_normal() {
+        assert_eq!(copy_value(Some("hello")), "hello");
+    }
+
+    #[test]
+    fn test_copy_value_special_chars() {
+        assert_eq!(copy_value(Some("a\tb")), "a\\tb");
+    }
+
+    // -- copy_line tests --
+
+    #[test]
+    fn test_copy_line_all_values() {
+        let line = copy_line(&[Some("1001"), Some("Test Title"), Some("US")]);
+        assert_eq!(line, "1001\tTest Title\tUS\n");
+    }
+
+    #[test]
+    fn test_copy_line_with_nulls() {
+        let line = copy_line(&[Some("1001"), None, Some("US")]);
+        assert_eq!(line, "1001\t\\N\tUS\n");
+    }
+
+    #[test]
+    fn test_copy_line_empty_string_becomes_null() {
+        let line = copy_line(&[Some("1001"), Some(""), Some("US")]);
+        assert_eq!(line, "1001\t\\N\tUS\n");
+    }
+
+    #[test]
+    fn test_copy_line_with_special_chars() {
+        let line = copy_line(&[Some("1"), Some("Title with\ttab"), Some("Note\nline2")]);
+        assert_eq!(line, "1\tTitle with\\ttab\tNote\\nline2\n");
+    }
+
+    // -- write_copy_row tests --
+
+    #[test]
+    fn test_write_copy_row_all_values() {
+        let mut buf = Vec::new();
+        write_copy_row(&mut buf, &[Some("1001"), Some("Test Title"), Some("US")]);
+        assert_eq!(buf, b"1001\tTest Title\tUS\n");
+    }
+
+    #[test]
+    fn test_write_copy_row_with_nulls() {
+        let mut buf = Vec::new();
+        write_copy_row(&mut buf, &[Some("1001"), None, Some("US")]);
+        assert_eq!(buf, b"1001\t\\N\tUS\n");
+    }
+
+    #[test]
+    fn test_write_copy_row_empty_string_becomes_null() {
+        let mut buf = Vec::new();
+        write_copy_row(&mut buf, &[Some("1001"), Some(""), Some("US")]);
+        assert_eq!(buf, b"1001\t\\N\tUS\n");
+    }
+
+    #[test]
+    fn test_write_copy_row_with_special_chars() {
+        let mut buf = Vec::new();
+        write_copy_row(
+            &mut buf,
+            &[Some("1"), Some("Title with\ttab"), Some("Note\nline2")],
+        );
+        assert_eq!(buf, b"1\tTitle with\\ttab\tNote\\nline2\n");
+    }
+
+    #[test]
+    fn test_write_copy_row_matches_copy_line() {
+        let test_cases: Vec<Vec<Option<&str>>> = vec![
+            vec![Some("1001"), Some("Test"), Some("US")],
+            vec![Some("1"), None, Some("value")],
+            vec![Some("42"), Some(""), Some("end")],
+            vec![Some("1"), Some("tab\there"), Some("nl\nhere")],
+        ];
+        for values in &test_cases {
+            let mut buf = Vec::new();
+            write_copy_row(&mut buf, values);
+            let expected = copy_line(values);
+            assert_eq!(
+                String::from_utf8(buf).unwrap(),
+                expected,
+                "Mismatch for values: {:?}",
+                values,
             );
         }
     }

--- a/wxyc-etl/src/pg/copy.rs
+++ b/wxyc-etl/src/pg/copy.rs
@@ -66,6 +66,14 @@ pub fn copy_line(values: &[Option<&str>]) -> String {
     line
 }
 
+/// Write an integer as a COPY TEXT column value directly into a byte buffer.
+///
+/// Uses [`itoa`] for zero-allocation integer formatting.
+pub fn write_copy_int(buf: &mut Vec<u8>, n: impl itoa::Integer) {
+    let mut itoa_buf = itoa::Buffer::new();
+    buf.extend_from_slice(itoa_buf.format(n).as_bytes());
+}
+
 /// Write a COPY TEXT row directly into a byte buffer.
 ///
 /// This is the zero-allocation counterpart of [`copy_line()`]. Values are
@@ -253,5 +261,35 @@ mod tests {
                 values,
             );
         }
+    }
+
+    // -- write_copy_int tests --
+
+    #[test]
+    fn test_write_copy_int_u64() {
+        let mut buf = Vec::new();
+        write_copy_int(&mut buf, 42u64);
+        assert_eq!(&buf, b"42");
+    }
+
+    #[test]
+    fn test_write_copy_int_negative() {
+        let mut buf = Vec::new();
+        write_copy_int(&mut buf, -7i32);
+        assert_eq!(&buf, b"-7");
+    }
+
+    #[test]
+    fn test_write_copy_int_zero() {
+        let mut buf = Vec::new();
+        write_copy_int(&mut buf, 0u32);
+        assert_eq!(&buf, b"0");
+    }
+
+    #[test]
+    fn test_write_copy_int_i16() {
+        let mut buf = Vec::new();
+        write_copy_int(&mut buf, 2001i16);
+        assert_eq!(&buf, b"2001");
     }
 }

--- a/wxyc-etl/src/pg/copy.rs
+++ b/wxyc-etl/src/pg/copy.rs
@@ -66,6 +66,27 @@ pub fn copy_line(values: &[Option<&str>]) -> String {
     line
 }
 
+/// Extract a 4-digit year from a Discogs "released" field.
+///
+/// Accepts formats like "1997-06-16" or "1997". Returns `None` if the
+/// string is shorter than 4 characters or doesn't start with 4 digits.
+pub fn extract_year(released: &str) -> Option<i16> {
+    if released.len() >= 4 && released.as_bytes()[..4].iter().all(|b| b.is_ascii_digit()) {
+        released[..4].parse().ok()
+    } else {
+        None
+    }
+}
+
+/// Convert an empty string to `None`.
+pub fn empty_to_none(s: &str) -> Option<&str> {
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
 /// Write an integer as a COPY TEXT column value directly into a byte buffer.
 ///
 /// Uses [`itoa`] for zero-allocation integer formatting.
@@ -291,5 +312,49 @@ mod tests {
         let mut buf = Vec::new();
         write_copy_int(&mut buf, 2001i16);
         assert_eq!(&buf, b"2001");
+    }
+
+    // -- extract_year tests --
+
+    #[test]
+    fn test_extract_year_full_date() {
+        assert_eq!(extract_year("1997-06-16"), Some(1997));
+    }
+
+    #[test]
+    fn test_extract_year_year_only() {
+        assert_eq!(extract_year("2024"), Some(2024));
+    }
+
+    #[test]
+    fn test_extract_year_empty() {
+        assert_eq!(extract_year(""), None);
+    }
+
+    #[test]
+    fn test_extract_year_non_numeric() {
+        assert_eq!(extract_year("Unknown"), None);
+    }
+
+    #[test]
+    fn test_extract_year_partial_digits() {
+        assert_eq!(extract_year("199"), None);
+    }
+
+    #[test]
+    fn test_extract_year_leading_zeros() {
+        assert_eq!(extract_year("0001-01-01"), Some(1));
+    }
+
+    // -- empty_to_none tests --
+
+    #[test]
+    fn test_empty_to_none_empty() {
+        assert_eq!(empty_to_none(""), None);
+    }
+
+    #[test]
+    fn test_empty_to_none_non_empty() {
+        assert_eq!(empty_to_none("hello"), Some("hello"));
     }
 }

--- a/wxyc-etl/src/pg/copy.rs
+++ b/wxyc-etl/src/pg/copy.rs
@@ -66,6 +66,27 @@ pub fn copy_line(values: &[Option<&str>]) -> String {
     line
 }
 
+/// Trait for accessing image type and URI from different image structs.
+///
+/// This allows [`pick_artwork_url()`] to be generic over different
+/// release image representations.
+pub trait ImageRef {
+    fn image_type(&self) -> &str;
+    fn uri(&self) -> &str;
+}
+
+/// Pick the best artwork URL from a slice of images.
+///
+/// Prefers the first "primary" image; falls back to the first image of any type.
+/// Returns `None` if the slice is empty.
+pub fn pick_artwork_url<I: ImageRef>(images: &[I]) -> Option<&str> {
+    let primary = images
+        .iter()
+        .find(|img| img.image_type() == "primary")
+        .map(|img| img.uri());
+    primary.or_else(|| images.first().map(|img| img.uri()))
+}
+
 /// Extract a 4-digit year from a Discogs "released" field.
 ///
 /// Accepts formats like "1997-06-16" or "1997". Returns `None` if the
@@ -356,5 +377,57 @@ mod tests {
     #[test]
     fn test_empty_to_none_non_empty() {
         assert_eq!(empty_to_none("hello"), Some("hello"));
+    }
+
+    // -- pick_artwork_url tests --
+
+    struct TestImage {
+        image_type: &'static str,
+        uri: &'static str,
+    }
+
+    impl ImageRef for TestImage {
+        fn image_type(&self) -> &str {
+            self.image_type
+        }
+        fn uri(&self) -> &str {
+            self.uri
+        }
+    }
+
+    #[test]
+    fn test_pick_artwork_prefers_primary() {
+        let images = vec![
+            TestImage {
+                image_type: "secondary",
+                uri: "https://img.discogs.com/secondary.jpg",
+            },
+            TestImage {
+                image_type: "primary",
+                uri: "https://img.discogs.com/primary.jpg",
+            },
+        ];
+        assert_eq!(
+            pick_artwork_url(&images),
+            Some("https://img.discogs.com/primary.jpg")
+        );
+    }
+
+    #[test]
+    fn test_pick_artwork_falls_back_to_first() {
+        let images = vec![TestImage {
+            image_type: "secondary",
+            uri: "https://img.discogs.com/first.jpg",
+        }];
+        assert_eq!(
+            pick_artwork_url(&images),
+            Some("https://img.discogs.com/first.jpg")
+        );
+    }
+
+    #[test]
+    fn test_pick_artwork_empty() {
+        let images: Vec<TestImage> = vec![];
+        assert_eq!(pick_artwork_url(&images), None);
     }
 }

--- a/wxyc-etl/src/pg/dedup.rs
+++ b/wxyc-etl/src/pg/dedup.rs
@@ -1,0 +1,114 @@
+//! In-memory deduplication trackers for PostgreSQL bulk imports.
+//!
+//! Prevents duplicate rows when multiple source records map to the same
+//! database key (e.g., same artist appearing twice on one release).
+
+use std::collections::HashSet;
+use std::hash::Hash;
+
+/// Generic deduplication tracker backed by a [`HashSet`].
+///
+/// Returns `true` on first insertion of a key, `false` on duplicates.
+/// Generalizes the `ArtistDedup`, `LabelDedup`, and `TrackArtistDedup`
+/// patterns from `discogs-xml-converter`.
+#[derive(Default)]
+pub struct DedupSet<K> {
+    seen: HashSet<K>,
+}
+
+impl<K: Eq + Hash> DedupSet<K> {
+    pub fn new() -> Self {
+        Self {
+            seen: HashSet::new(),
+        }
+    }
+
+    /// Returns `true` if this is the first occurrence (not a duplicate).
+    pub fn insert(&mut self, key: K) -> bool {
+        self.seen.insert(key)
+    }
+
+    /// Number of unique keys seen so far.
+    pub fn len(&self) -> usize {
+        self.seen.len()
+    }
+
+    /// Returns `true` if no keys have been inserted.
+    pub fn is_empty(&self) -> bool {
+        self.seen.is_empty()
+    }
+}
+
+/// Dedup tracker for (release_id, artist_name) pairs.
+pub type ArtistDedup = DedupSet<(u64, String)>;
+
+/// Dedup tracker for (release_id, label_name) pairs.
+pub type LabelDedup = DedupSet<(u64, String)>;
+
+/// Dedup tracker for (release_id, track_sequence, artist_name) tuples.
+pub type TrackArtistDedup = DedupSet<(u64, u32, String)>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_first_insert_returns_true() {
+        let mut dedup = DedupSet::<(u64, String)>::new();
+        assert!(dedup.insert((1, "Autechre".to_string())));
+    }
+
+    #[test]
+    fn test_duplicate_returns_false() {
+        let mut dedup = DedupSet::<(u64, String)>::new();
+        dedup.insert((1, "Autechre".to_string()));
+        assert!(!dedup.insert((1, "Autechre".to_string())));
+    }
+
+    #[test]
+    fn test_different_keys_both_true() {
+        let mut dedup = DedupSet::<(u64, String)>::new();
+        assert!(dedup.insert((1, "Autechre".to_string())));
+        assert!(dedup.insert((1, "Stereolab".to_string())));
+    }
+
+    #[test]
+    fn test_len_and_is_empty() {
+        let mut dedup = DedupSet::<u32>::new();
+        assert!(dedup.is_empty());
+        assert_eq!(dedup.len(), 0);
+        dedup.insert(1);
+        assert!(!dedup.is_empty());
+        assert_eq!(dedup.len(), 1);
+        dedup.insert(1); // duplicate
+        assert_eq!(dedup.len(), 1);
+    }
+
+    #[test]
+    fn test_artist_dedup() {
+        let mut dedup = ArtistDedup::new();
+        assert!(dedup.insert((1001, "Autechre".to_string())));
+        assert!(dedup.insert((1001, "Boards of Canada".to_string())));
+        assert!(!dedup.insert((1001, "Autechre".to_string())));
+        // Same artist, different release
+        assert!(dedup.insert((1002, "Autechre".to_string())));
+    }
+
+    #[test]
+    fn test_track_artist_dedup() {
+        let mut dedup = TrackArtistDedup::new();
+        assert!(dedup.insert((1001, 1, "Autechre".to_string())));
+        assert!(dedup.insert((1001, 2, "Autechre".to_string())));
+        assert!(!dedup.insert((1001, 1, "Autechre".to_string())));
+        assert!(dedup.insert((1001, 1, "Boards of Canada".to_string())));
+    }
+
+    #[test]
+    fn test_label_dedup() {
+        let mut dedup = LabelDedup::new();
+        assert!(dedup.insert((1001, "Warp".to_string())));
+        assert!(dedup.insert((1001, "4AD".to_string())));
+        assert!(!dedup.insert((1001, "Warp".to_string())));
+        assert!(dedup.insert((1002, "Warp".to_string())));
+    }
+}

--- a/wxyc-etl/src/pg/mod.rs
+++ b/wxyc-etl/src/pg/mod.rs
@@ -1,1 +1,7 @@
-//! pg module — see implementation plan for details.
+//! PostgreSQL bulk loading utilities.
+//!
+//! Provides COPY TEXT escaping, row formatting, buffered batch writing,
+//! deduplication tracking, and administrative operations for PostgreSQL
+//! bulk imports.
+
+pub mod copy;

--- a/wxyc-etl/src/pg/mod.rs
+++ b/wxyc-etl/src/pg/mod.rs
@@ -5,3 +5,4 @@
 //! bulk imports.
 
 pub mod copy;
+pub mod dedup;

--- a/wxyc-etl/src/pg/mod.rs
+++ b/wxyc-etl/src/pg/mod.rs
@@ -1,0 +1,1 @@
+//! pg module — see implementation plan for details.

--- a/wxyc-etl/src/pg/mod.rs
+++ b/wxyc-etl/src/pg/mod.rs
@@ -4,5 +4,6 @@
 //! deduplication tracking, and administrative operations for PostgreSQL
 //! bulk imports.
 
+pub mod batch;
 pub mod copy;
 pub mod dedup;

--- a/wxyc-etl/src/pg/mod.rs
+++ b/wxyc-etl/src/pg/mod.rs
@@ -4,6 +4,7 @@
 //! deduplication tracking, and administrative operations for PostgreSQL
 //! bulk imports.
 
+pub mod admin;
 pub mod batch;
 pub mod copy;
 pub mod dedup;

--- a/wxyc-etl/src/pg/mod.rs
+++ b/wxyc-etl/src/pg/mod.rs
@@ -3,8 +3,23 @@
 //! Provides COPY TEXT escaping, row formatting, buffered batch writing,
 //! deduplication tracking, and administrative operations for PostgreSQL
 //! bulk imports.
+//!
+//! # Quick start
+//!
+//! ```ignore
+//! use wxyc_etl::pg::{escape_copy_text, write_copy_row, write_copy_int, BatchCopier, DedupSet, extract_year};
+//! ```
 
 pub mod admin;
 pub mod batch;
 pub mod copy;
 pub mod dedup;
+
+// Re-export commonly used items at the pg module level.
+pub use admin::{set_tables_logged, set_tables_unlogged, vacuum_full};
+pub use batch::{BatchCopier, CopyBuffer, CopyTarget};
+pub use copy::{
+    copy_line, copy_value, empty_to_none, escape_copy_text, escape_copy_text_into, extract_year,
+    pick_artwork_url, write_copy_int, write_copy_row, ImageRef,
+};
+pub use dedup::{ArtistDedup, DedupSet, LabelDedup, TrackArtistDedup};

--- a/wxyc-etl/src/pipeline/mod.rs
+++ b/wxyc-etl/src/pipeline/mod.rs
@@ -1,0 +1,1 @@
+//! pipeline module — see implementation plan for details.

--- a/wxyc-etl/src/schema/mod.rs
+++ b/wxyc-etl/src/schema/mod.rs
@@ -1,0 +1,1 @@
+//! schema module — see implementation plan for details.

--- a/wxyc-etl/src/sqlite/mod.rs
+++ b/wxyc-etl/src/sqlite/mod.rs
@@ -1,0 +1,1 @@
+//! sqlite module — see implementation plan for details.

--- a/wxyc-etl/src/state/mod.rs
+++ b/wxyc-etl/src/state/mod.rs
@@ -1,0 +1,1 @@
+//! state module — see implementation plan for details.

--- a/wxyc-etl/src/text/mod.rs
+++ b/wxyc-etl/src/text/mod.rs
@@ -1,0 +1,1 @@
+//! text module — see implementation plan for details.


### PR DESCRIPTION
## Summary

- Extracts PostgreSQL COPY TEXT helpers from `discogs-xml-converter/src/pg_output.rs` into `wxyc-etl/src/pg/`
- Adds `BatchCopier` with FK-ordered flush and `CopyTarget` trait for testability
- Adds `DedupSet<K>` generic dedup tracker generalizing `ArtistDedup`, `LabelDedup`, `TrackArtistDedup`
- Adds `set_tables_unlogged()` / `set_tables_logged()` / `vacuum_full()` ported from discogs-cache Python scripts
- Adds `ImageRef` trait and generic `pick_artwork_url()` for artwork selection

Closes #11

## Test plan

- [x] 56 unit tests pass via `cargo test -p wxyc-etl --lib pg`
- [x] Integration tests for admin functions pass when `TEST_DATABASE_URL` is set
- [x] `escape_copy_text()` and `escape_copy_text_into()` produce identical output for all escape sequences
- [x] `write_copy_row()` matches `copy_line()` output for all test cases
- [x] `BatchCopier` flushes tables in FK-parent-before-children order
- [x] `DedupSet<K>` correctly tracks first-seen vs. duplicate insertions
- [x] `extract_year()` matches behavior of both `pg_output.rs` and `import_csv.py`
- [x] Table name validation prevents SQL injection in admin functions
- [ ] No breaking changes to discogs-xml-converter (adoption happens in Phase 3)