### PR TITLE
Extract csv_writer, sqlite, state, import, schema modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,8 @@
+[workspace]
+members = ["wxyc-etl", "wxyc-etl-python"]
+resolver = "2"
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "MIT"

--- a/wxyc-etl-python/Cargo.toml
+++ b/wxyc-etl-python/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "wxyc-etl-python"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+name = "wxyc_etl"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.22", features = ["extension-module"] }
+wxyc-etl = { path = "../wxyc-etl" }

--- a/wxyc-etl-python/src/lib.rs
+++ b/wxyc-etl-python/src/lib.rs
@@ -1,0 +1,6 @@
+use pyo3::prelude::*;
+
+#[pymodule]
+fn wxyc_etl(_py: Python, _m: &Bound<'_, PyModule>) -> PyResult<()> {
+    Ok(())
+}

--- a/wxyc-etl/Cargo.toml
+++ b/wxyc-etl/Cargo.toml
@@ -8,7 +8,7 @@ description = "Shared ETL crate for the WXYC music data pipeline"
 [dependencies]
 # text module
 unicode-normalization = "0.1"
-unicode-categories = "0.1"
+unicode_categories = "0.1"
 
 # pg module
 postgres = "0.19"

--- a/wxyc-etl/Cargo.toml
+++ b/wxyc-etl/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "wxyc-etl"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Shared ETL crate for the WXYC music data pipeline"
+
+[dependencies]
+# text module
+unicode-normalization = "0.1"
+unicode-categories = "0.1"
+
+# pg module
+postgres = "0.19"
+itoa = "1"
+
+# pipeline module
+crossbeam-channel = "0.5"
+rayon = "1.10"
+
+# csv module
+csv = "1.3"
+
+# sqlite module
+rusqlite = { version = "0.31", features = ["bundled"] }
+
+# state/import modules
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# fuzzy module
+strsim = "0.11"
+
+# parser module
+memmap2 = "0.9"
+memchr = "2"
+
+# shared
+anyhow = "1"
+log = "0.4"
+env_logger = "0.11"
+
+[dev-dependencies]
+tempfile = "3"

--- a/wxyc-etl/src/csv_writer/mod.rs
+++ b/wxyc-etl/src/csv_writer/mod.rs
@@ -1,1 +1,84 @@
-//! csv_writer module — see implementation plan for details.
+//! Multi-file CSV writer for ETL pipelines.
+//!
+//! Manages N `csv::Writer` instances (one per output file), each with
+//! pre-written headers. Ported from the per-repo writer patterns in
+//! `discogs-xml-converter/src/writer.rs` and `wikidata-json-filter/src/writer.rs`.
+
+mod writer;
+
+pub use writer::{CsvFileSpec, MultiCsvWriter};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn creates_files_with_headers() {
+        let dir = tempfile::tempdir().unwrap();
+        let specs = vec![
+            CsvFileSpec::new("release.csv", &["id", "title", "country"]),
+            CsvFileSpec::new("release_artist.csv", &["release_id", "artist_name"]),
+        ];
+        let writer = MultiCsvWriter::new(dir.path(), &specs).unwrap();
+        drop(writer);
+
+        let content = std::fs::read_to_string(dir.path().join("release.csv")).unwrap();
+        assert!(content.starts_with("id,title,country\n"));
+
+        let content2 = std::fs::read_to_string(dir.path().join("release_artist.csv")).unwrap();
+        assert!(content2.starts_with("release_id,artist_name\n"));
+    }
+
+    #[test]
+    fn creates_output_directory_if_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("sub").join("dir");
+        let specs = vec![CsvFileSpec::new("test.csv", &["a"])];
+        let writer = MultiCsvWriter::new(&nested, &specs).unwrap();
+        assert!(nested.exists());
+        drop(writer);
+    }
+
+    #[test]
+    fn write_and_flush() {
+        let dir = tempfile::tempdir().unwrap();
+        let specs = vec![CsvFileSpec::new("test.csv", &["a", "b"])];
+        let mut writer = MultiCsvWriter::new(dir.path(), &specs).unwrap();
+        writer.writer(0).write_record(&["1", "hello"]).unwrap();
+        writer.flush_all().unwrap();
+
+        let mut rdr = csv::Reader::from_path(dir.path().join("test.csv")).unwrap();
+        let records: Vec<_> = rdr.records().map(|r| r.unwrap()).collect();
+        assert_eq!(records.len(), 1);
+        assert_eq!(&records[0][0], "1");
+        assert_eq!(&records[0][1], "hello");
+    }
+
+    #[test]
+    fn writer_by_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let specs = vec![
+            CsvFileSpec::new("a.csv", &["x"]),
+            CsvFileSpec::new("b.csv", &["y"]),
+        ];
+        let mut writer = MultiCsvWriter::new(dir.path(), &specs).unwrap();
+        writer
+            .writer_by_name("b.csv")
+            .unwrap()
+            .write_record(&["42"])
+            .unwrap();
+        writer.flush_all().unwrap();
+
+        let content = std::fs::read_to_string(dir.path().join("b.csv")).unwrap();
+        assert!(content.contains("42"));
+        assert!(writer.writer_by_name("nonexistent.csv").is_none());
+    }
+
+    #[test]
+    fn output_dir_accessor() {
+        let dir = tempfile::tempdir().unwrap();
+        let specs = vec![CsvFileSpec::new("test.csv", &["a"])];
+        let writer = MultiCsvWriter::new(dir.path(), &specs).unwrap();
+        assert_eq!(writer.output_dir(), dir.path());
+    }
+}

--- a/wxyc-etl/src/csv_writer/mod.rs
+++ b/wxyc-etl/src/csv_writer/mod.rs
@@ -1,0 +1,1 @@
+//! csv_writer module — see implementation plan for details.

--- a/wxyc-etl/src/csv_writer/writer.rs
+++ b/wxyc-etl/src/csv_writer/writer.rs
@@ -1,0 +1,80 @@
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+/// Specification for one output CSV file: filename and header columns.
+pub struct CsvFileSpec {
+    pub filename: String,
+    pub columns: Vec<String>,
+}
+
+impl CsvFileSpec {
+    pub fn new(filename: &str, columns: &[&str]) -> Self {
+        Self {
+            filename: filename.to_string(),
+            columns: columns.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+}
+
+/// Manages N `csv::Writer` instances, one per `CsvFileSpec`, with a shared output directory.
+pub struct MultiCsvWriter {
+    writers: Vec<csv::Writer<File>>,
+    filenames: Vec<String>,
+    output_dir: PathBuf,
+}
+
+impl MultiCsvWriter {
+    /// Create the output directory and open all writers with headers.
+    pub fn new(output_dir: &Path, specs: &[CsvFileSpec]) -> Result<Self> {
+        fs::create_dir_all(output_dir)
+            .with_context(|| format!("creating output directory {}", output_dir.display()))?;
+
+        let mut writers = Vec::with_capacity(specs.len());
+        let mut filenames = Vec::with_capacity(specs.len());
+
+        for spec in specs {
+            let path = output_dir.join(&spec.filename);
+            let mut wtr = csv::Writer::from_path(&path)
+                .with_context(|| format!("creating CSV writer for {}", path.display()))?;
+            wtr.write_record(&spec.columns)
+                .with_context(|| format!("writing headers to {}", spec.filename))?;
+            writers.push(wtr);
+            filenames.push(spec.filename.clone());
+        }
+
+        Ok(Self {
+            writers,
+            filenames,
+            output_dir: output_dir.to_path_buf(),
+        })
+    }
+
+    /// Get a writer by spec index.
+    pub fn writer(&mut self, index: usize) -> &mut csv::Writer<File> {
+        &mut self.writers[index]
+    }
+
+    /// Get a writer by filename.
+    pub fn writer_by_name(&mut self, filename: &str) -> Option<&mut csv::Writer<File>> {
+        self.filenames
+            .iter()
+            .position(|f| f == filename)
+            .map(|i| &mut self.writers[i])
+    }
+
+    /// Flush all writers.
+    pub fn flush_all(&mut self) -> Result<()> {
+        for (wtr, name) in self.writers.iter_mut().zip(self.filenames.iter()) {
+            wtr.flush()
+                .with_context(|| format!("flushing writer for {}", name))?;
+        }
+        Ok(())
+    }
+
+    /// Return the output directory path.
+    pub fn output_dir(&self) -> &Path {
+        &self.output_dir
+    }
+}

--- a/wxyc-etl/src/fuzzy/mod.rs
+++ b/wxyc-etl/src/fuzzy/mod.rs
@@ -1,0 +1,1 @@
+//! fuzzy module — see implementation plan for details.

--- a/wxyc-etl/src/import/dedup.rs
+++ b/wxyc-etl/src/import/dedup.rs
@@ -1,0 +1,38 @@
+use std::collections::HashSet;
+
+/// Tracks seen rows by unique key tuple during CSV import.
+///
+/// Generalizes the `seen: set[tuple]` pattern from `import_csv.py`.
+pub struct ImportDedupSet {
+    seen: HashSet<Vec<String>>,
+}
+
+impl ImportDedupSet {
+    pub fn new() -> Self {
+        Self {
+            seen: HashSet::new(),
+        }
+    }
+
+    /// Insert a key. Returns `true` if the key was not already present (i.e., not a duplicate).
+    pub fn insert(&mut self, key: &[&str]) -> bool {
+        let owned: Vec<String> = key.iter().map(|s| s.to_string()).collect();
+        self.seen.insert(owned)
+    }
+
+    /// Return the number of unique keys seen so far.
+    pub fn len(&self) -> usize {
+        self.seen.len()
+    }
+
+    /// Return true if no keys have been inserted.
+    pub fn is_empty(&self) -> bool {
+        self.seen.is_empty()
+    }
+}
+
+impl Default for ImportDedupSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/wxyc-etl/src/import/mapping.rs
+++ b/wxyc-etl/src/import/mapping.rs
@@ -1,0 +1,58 @@
+use std::collections::HashMap;
+
+/// A function that transforms a column value during import.
+pub type TransformFn = Box<dyn Fn(Option<&str>) -> Option<String>>;
+
+/// Describes how to map source columns (CSV/TSV) to database columns.
+///
+/// Unifies the column mapping pattern from `discogs-cache/scripts/import_csv.py`
+/// `TableConfig` and `musicbrainz-cache/scripts/import_tsv.py` `TableSpec`.
+pub struct ColumnMapping {
+    /// Column names to read from the source file.
+    pub source_columns: Vec<String>,
+    /// Corresponding database column names.
+    pub db_columns: Vec<String>,
+    /// Columns that must not be NULL.
+    pub required_columns: Vec<String>,
+    /// Columns forming the dedup key (if any).
+    pub unique_key: Option<Vec<String>>,
+    /// Per-column value transforms, keyed by source column name.
+    pub transforms: HashMap<String, TransformFn>,
+}
+
+impl ColumnMapping {
+    /// Create a new column mapping.
+    pub fn new(
+        source_columns: Vec<String>,
+        db_columns: Vec<String>,
+        required_columns: Vec<String>,
+        unique_key: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            source_columns,
+            db_columns,
+            required_columns,
+            unique_key,
+            transforms: HashMap::new(),
+        }
+    }
+
+    /// Add a per-column transform function.
+    pub fn add_transform(&mut self, column: &str, transform: TransformFn) {
+        self.transforms.insert(column.to_string(), transform);
+    }
+
+    /// Return the index of a source column by name, or None.
+    pub fn source_index(&self, name: &str) -> Option<usize> {
+        self.source_columns.iter().position(|c| c == name)
+    }
+
+    /// Return the indices of the unique key columns in the source columns list.
+    pub fn unique_key_indices(&self) -> Option<Vec<usize>> {
+        self.unique_key.as_ref().map(|keys| {
+            keys.iter()
+                .filter_map(|k| self.source_index(k))
+                .collect()
+        })
+    }
+}

--- a/wxyc-etl/src/import/mod.rs
+++ b/wxyc-etl/src/import/mod.rs
@@ -1,0 +1,1 @@
+//! import module — see implementation plan for details.

--- a/wxyc-etl/src/import/mod.rs
+++ b/wxyc-etl/src/import/mod.rs
@@ -1,1 +1,95 @@
-//! import module — see implementation plan for details.
+//! Column mapping and deduplication for CSV/TSV import.
+//!
+//! Unifies the import patterns from `discogs-cache/scripts/import_csv.py`
+//! (`TableConfig`) and `musicbrainz-cache/scripts/import_tsv.py` (`TableSpec`).
+
+mod dedup;
+mod mapping;
+
+pub use dedup::ImportDedupSet;
+pub use mapping::{ColumnMapping, TransformFn};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_mapping_basic() {
+        let mapping = ColumnMapping::new(
+            vec!["id".into(), "title".into()],
+            vec!["id".into(), "title".into()],
+            vec!["id".into()],
+            None,
+        );
+        assert_eq!(mapping.source_columns.len(), 2);
+        assert_eq!(mapping.required_columns, vec!["id"]);
+        assert_eq!(mapping.source_index("title"), Some(1));
+        assert_eq!(mapping.source_index("nonexistent"), None);
+    }
+
+    #[test]
+    fn column_mapping_with_unique_key() {
+        let mapping = ColumnMapping::new(
+            vec!["release_id".into(), "artist_name".into(), "extra".into()],
+            vec!["release_id".into(), "artist_name".into(), "extra".into()],
+            vec!["release_id".into()],
+            Some(vec!["release_id".into(), "artist_name".into()]),
+        );
+        let indices = mapping.unique_key_indices().unwrap();
+        assert_eq!(indices, vec![0, 1]);
+    }
+
+    #[test]
+    fn column_mapping_with_transform() {
+        let mut mapping = ColumnMapping::new(
+            vec!["format".into()],
+            vec!["format".into()],
+            vec![],
+            None,
+        );
+        mapping.add_transform(
+            "format",
+            Box::new(|v| v.map(|s| s.to_uppercase())),
+        );
+        let transform = mapping.transforms.get("format").unwrap();
+        assert_eq!(transform(Some("vinyl")), Some("VINYL".to_string()));
+        assert_eq!(transform(None), None);
+    }
+
+    #[test]
+    fn column_mapping_different_source_and_db_columns() {
+        let mapping = ColumnMapping::new(
+            vec!["label".into(), "catno".into()],
+            vec!["label_name".into(), "catno".into()],
+            vec!["label_name".into()],
+            None,
+        );
+        assert_eq!(mapping.source_columns[0], "label");
+        assert_eq!(mapping.db_columns[0], "label_name");
+    }
+
+    #[test]
+    fn dedup_set_basic() {
+        let mut dedup = ImportDedupSet::new();
+        assert!(dedup.is_empty());
+        assert!(dedup.insert(&["1", "Autechre"]));
+        assert!(!dedup.insert(&["1", "Autechre"])); // duplicate
+        assert!(dedup.insert(&["1", "Stereolab"])); // different key
+        assert_eq!(dedup.len(), 2);
+    }
+
+    #[test]
+    fn dedup_set_single_column_key() {
+        let mut dedup = ImportDedupSet::new();
+        assert!(dedup.insert(&["42"]));
+        assert!(!dedup.insert(&["42"]));
+        assert!(dedup.insert(&["43"]));
+    }
+
+    #[test]
+    fn dedup_set_empty_key() {
+        let mut dedup = ImportDedupSet::new();
+        assert!(dedup.insert(&[]));
+        assert!(!dedup.insert(&[])); // duplicate empty key
+    }
+}

--- a/wxyc-etl/src/lib.rs
+++ b/wxyc-etl/src/lib.rs
@@ -1,0 +1,15 @@
+//! Shared ETL crate for the WXYC music data pipeline.
+//!
+//! Provides text normalization, fuzzy matching, PostgreSQL bulk loading,
+//! pipeline orchestration, and schema contracts.
+
+pub mod text;
+pub mod pg;
+pub mod pipeline;
+pub mod csv_writer;
+pub mod sqlite;
+pub mod state;
+pub mod import;
+pub mod schema;
+pub mod fuzzy;
+pub mod parser;

--- a/wxyc-etl/src/parser/mod.rs
+++ b/wxyc-etl/src/parser/mod.rs
@@ -1,0 +1,1 @@
+//! parser module — see implementation plan for details.

--- a/wxyc-etl/src/pg/mod.rs
+++ b/wxyc-etl/src/pg/mod.rs
@@ -1,0 +1,1 @@
+//! pg module — see implementation plan for details.

--- a/wxyc-etl/src/pipeline/mod.rs
+++ b/wxyc-etl/src/pipeline/mod.rs
@@ -1,0 +1,1 @@
+//! pipeline module — see implementation plan for details.

--- a/wxyc-etl/src/schema/discogs.rs
+++ b/wxyc-etl/src/schema/discogs.rs
@@ -1,0 +1,111 @@
+//! Discogs-cache table and column constants.
+//!
+//! Matches the PostgreSQL schema in `discogs-cache/schema/create_database.sql`.
+
+// -- Release tables --
+
+pub const RELEASE_TABLE: &str = "release";
+pub const RELEASE_COLUMNS: &[&str] = &[
+    "id",
+    "title",
+    "release_year",
+    "country",
+    "artwork_url",
+    "released",
+    "format",
+    "master_id",
+];
+
+pub const RELEASE_ARTIST_TABLE: &str = "release_artist";
+pub const RELEASE_ARTIST_COLUMNS: &[&str] = &[
+    "release_id",
+    "artist_id",
+    "artist_name",
+    "extra",
+    "role",
+];
+
+pub const RELEASE_LABEL_TABLE: &str = "release_label";
+pub const RELEASE_LABEL_COLUMNS: &[&str] = &[
+    "release_id",
+    "label_id",
+    "label_name",
+    "catno",
+];
+
+pub const RELEASE_GENRE_TABLE: &str = "release_genre";
+pub const RELEASE_GENRE_COLUMNS: &[&str] = &["release_id", "genre"];
+
+pub const RELEASE_STYLE_TABLE: &str = "release_style";
+pub const RELEASE_STYLE_COLUMNS: &[&str] = &["release_id", "style"];
+
+pub const RELEASE_TRACK_TABLE: &str = "release_track";
+pub const RELEASE_TRACK_COLUMNS: &[&str] = &[
+    "release_id",
+    "sequence",
+    "position",
+    "title",
+    "duration",
+];
+
+pub const RELEASE_TRACK_ARTIST_TABLE: &str = "release_track_artist";
+pub const RELEASE_TRACK_ARTIST_COLUMNS: &[&str] = &[
+    "release_id",
+    "track_sequence",
+    "artist_name",
+];
+
+// -- Artist detail tables --
+
+pub const ARTIST_TABLE: &str = "artist";
+pub const ARTIST_COLUMNS: &[&str] = &[
+    "id",
+    "name",
+    "profile",
+    "image_url",
+    "fetched_at",
+];
+
+pub const ARTIST_ALIAS_TABLE: &str = "artist_alias";
+pub const ARTIST_ALIAS_COLUMNS: &[&str] = &["artist_id", "alias_id", "alias_name"];
+
+pub const ARTIST_NAME_VARIATION_TABLE: &str = "artist_name_variation";
+pub const ARTIST_NAME_VARIATION_COLUMNS: &[&str] = &["artist_id", "name"];
+
+pub const ARTIST_MEMBER_TABLE: &str = "artist_member";
+pub const ARTIST_MEMBER_COLUMNS: &[&str] = &[
+    "artist_id",
+    "member_id",
+    "member_name",
+    "active",
+];
+
+pub const ARTIST_URL_TABLE: &str = "artist_url";
+pub const ARTIST_URL_COLUMNS: &[&str] = &["artist_id", "url"];
+
+// -- Metadata tables --
+
+pub const CACHE_METADATA_TABLE: &str = "cache_metadata";
+pub const CACHE_METADATA_COLUMNS: &[&str] = &[
+    "release_id",
+    "cached_at",
+    "source",
+    "last_validated",
+];
+
+/// All table names in the discogs-cache schema.
+pub const ALL_TABLES: &[&str] = &[
+    RELEASE_TABLE,
+    RELEASE_ARTIST_TABLE,
+    RELEASE_LABEL_TABLE,
+    RELEASE_GENRE_TABLE,
+    RELEASE_STYLE_TABLE,
+    RELEASE_TRACK_TABLE,
+    RELEASE_TRACK_ARTIST_TABLE,
+    ARTIST_TABLE,
+    ARTIST_ALIAS_TABLE,
+    ARTIST_NAME_VARIATION_TABLE,
+    ARTIST_MEMBER_TABLE,
+    ARTIST_URL_TABLE,
+    CACHE_METADATA_TABLE,
+];

--- a/wxyc-etl/src/schema/entity.rs
+++ b/wxyc-etl/src/schema/entity.rs
@@ -1,0 +1,61 @@
+//! Entity store schema constants.
+//!
+//! Matches the entity store DDL from the architecture document
+//! (`etl-pipeline-architecture.md`). These constants are placeholders to be
+//! finalized when task 5a is implemented; 5a's DDL is the source of truth.
+
+pub const ENTITY_IDENTITY_TABLE: &str = "entity.identity";
+
+pub const ENTITY_IDENTITY_COLUMNS: &[&str] = &[
+    "id",
+    "library_name",
+    "discogs_artist_id",
+    "wikidata_qid",
+    "musicbrainz_artist_id",
+    "spotify_artist_id",
+    "apple_music_artist_id",
+    "bandcamp_id",
+    "reconciliation_status",
+    "created_at",
+    "updated_at",
+];
+
+pub const ENTITY_IDENTITY_DDL: &str = "\
+CREATE SCHEMA IF NOT EXISTS entity;
+
+CREATE TABLE entity.identity (
+    id SERIAL PRIMARY KEY,
+    library_name TEXT NOT NULL UNIQUE,
+    discogs_artist_id INTEGER,
+    wikidata_qid TEXT,
+    musicbrainz_artist_id TEXT,
+    spotify_artist_id TEXT,
+    apple_music_artist_id TEXT,
+    bandcamp_id TEXT,
+    reconciliation_status TEXT NOT NULL DEFAULT 'unreconciled',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)";
+
+pub const RECONCILIATION_LOG_TABLE: &str = "entity.reconciliation_log";
+
+pub const RECONCILIATION_LOG_COLUMNS: &[&str] = &[
+    "id",
+    "identity_id",
+    "source",
+    "external_id",
+    "confidence",
+    "method",
+    "created_at",
+];
+
+pub const RECONCILIATION_LOG_DDL: &str = "\
+CREATE TABLE entity.reconciliation_log (
+    id SERIAL PRIMARY KEY,
+    identity_id INTEGER NOT NULL REFERENCES entity.identity(id),
+    source TEXT NOT NULL,
+    external_id TEXT NOT NULL,
+    confidence REAL,
+    method TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)";

--- a/wxyc-etl/src/schema/library.rs
+++ b/wxyc-etl/src/schema/library.rs
@@ -1,0 +1,41 @@
+//! library.db schema constants.
+//!
+//! Matches the SQLite schema in `discogs-cache/scripts/export_to_sqlite.py`.
+
+pub const LIBRARY_TABLE: &str = "library";
+
+pub const LIBRARY_COLUMNS: &[&str] = &[
+    "id",
+    "title",
+    "artist",
+    "call_letters",
+    "artist_call_number",
+    "release_call_number",
+    "genre",
+    "format",
+    "alternate_artist_name",
+];
+
+pub const LIBRARY_DDL: &str = "\
+CREATE TABLE library (
+    id INTEGER PRIMARY KEY,
+    title TEXT,
+    artist TEXT,
+    call_letters TEXT,
+    artist_call_number INTEGER,
+    release_call_number INTEGER,
+    genre TEXT,
+    format TEXT,
+    alternate_artist_name TEXT
+)";
+
+pub const LIBRARY_FTS_TABLE: &str = "library_fts";
+
+pub const LIBRARY_FTS_DDL: &str = "\
+CREATE VIRTUAL TABLE library_fts USING fts5(
+    title,
+    artist,
+    alternate_artist_name,
+    content='library',
+    content_rowid='id'
+)";

--- a/wxyc-etl/src/schema/mod.rs
+++ b/wxyc-etl/src/schema/mod.rs
@@ -1,1 +1,172 @@
-//! schema module — see implementation plan for details.
+//! Schema contracts: table names, column lists, and DDL constants.
+//!
+//! Provides shared constants for all database schemas consumed by the ETL
+//! pipeline: library.db (SQLite), discogs-cache (PostgreSQL), entity store
+//! (PostgreSQL), wikidata-cache (PostgreSQL), and musicbrainz-cache (PostgreSQL).
+
+pub mod discogs;
+pub mod entity;
+pub mod library;
+pub mod musicbrainz;
+pub mod wikidata;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Library --
+
+    #[test]
+    fn library_table_name() {
+        assert_eq!(library::LIBRARY_TABLE, "library");
+    }
+
+    #[test]
+    fn library_columns_contains_required() {
+        assert!(library::LIBRARY_COLUMNS.contains(&"artist"));
+        assert!(library::LIBRARY_COLUMNS.contains(&"title"));
+        assert!(library::LIBRARY_COLUMNS.contains(&"id"));
+        assert!(library::LIBRARY_COLUMNS.contains(&"format"));
+    }
+
+    #[test]
+    fn library_ddl_contains_columns() {
+        assert!(library::LIBRARY_DDL.contains("artist"));
+        assert!(library::LIBRARY_DDL.contains("title"));
+        assert!(library::LIBRARY_DDL.contains("id INTEGER PRIMARY KEY"));
+    }
+
+    #[test]
+    fn library_fts_ddl() {
+        assert!(library::LIBRARY_FTS_DDL.contains("fts5"));
+        assert!(library::LIBRARY_FTS_DDL.contains("content='library'"));
+    }
+
+    // -- Discogs --
+
+    #[test]
+    fn discogs_release_table() {
+        assert_eq!(discogs::RELEASE_TABLE, "release");
+        assert!(discogs::RELEASE_COLUMNS.contains(&"id"));
+        assert!(discogs::RELEASE_COLUMNS.contains(&"title"));
+        assert!(discogs::RELEASE_COLUMNS.contains(&"master_id"));
+    }
+
+    #[test]
+    fn discogs_all_tables_count() {
+        assert_eq!(discogs::ALL_TABLES.len(), 13);
+    }
+
+    #[test]
+    fn discogs_release_artist_columns() {
+        assert!(discogs::RELEASE_ARTIST_COLUMNS.contains(&"release_id"));
+        assert!(discogs::RELEASE_ARTIST_COLUMNS.contains(&"artist_name"));
+    }
+
+    #[test]
+    fn discogs_release_label_columns() {
+        assert!(discogs::RELEASE_LABEL_COLUMNS.contains(&"label_name"));
+        assert!(discogs::RELEASE_LABEL_COLUMNS.contains(&"catno"));
+    }
+
+    #[test]
+    fn discogs_artist_columns() {
+        assert!(discogs::ARTIST_COLUMNS.contains(&"id"));
+        assert!(discogs::ARTIST_COLUMNS.contains(&"name"));
+        assert!(discogs::ARTIST_COLUMNS.contains(&"profile"));
+    }
+
+    // -- Entity --
+
+    #[test]
+    fn entity_identity_ddl() {
+        assert!(entity::ENTITY_IDENTITY_DDL.contains("library_name"));
+        assert!(entity::ENTITY_IDENTITY_DDL.contains("discogs_artist_id"));
+        assert!(entity::ENTITY_IDENTITY_DDL.contains("wikidata_qid"));
+        assert!(entity::ENTITY_IDENTITY_DDL.contains("musicbrainz_artist_id"));
+        assert!(entity::ENTITY_IDENTITY_DDL.contains("reconciliation_status"));
+    }
+
+    #[test]
+    fn entity_reconciliation_log_ddl() {
+        assert!(entity::RECONCILIATION_LOG_DDL.contains("identity_id"));
+        assert!(entity::RECONCILIATION_LOG_DDL.contains("confidence"));
+        assert!(entity::RECONCILIATION_LOG_DDL.contains("method"));
+    }
+
+    #[test]
+    fn entity_identity_table_name() {
+        assert_eq!(entity::ENTITY_IDENTITY_TABLE, "entity.identity");
+    }
+
+    // -- Wikidata --
+
+    #[test]
+    fn wikidata_all_tables_count() {
+        assert_eq!(wikidata::ALL_TABLES.len(), 8);
+    }
+
+    #[test]
+    fn wikidata_entity_table() {
+        assert_eq!(wikidata::ENTITY_TABLE, "entity");
+        assert!(wikidata::ENTITY_COLUMNS.contains(&"qid"));
+        assert!(wikidata::ENTITY_COLUMNS.contains(&"entity_type"));
+    }
+
+    #[test]
+    fn wikidata_discogs_mapping_table() {
+        assert_eq!(wikidata::DISCOGS_MAPPING_TABLE, "discogs_mapping");
+        assert!(wikidata::DISCOGS_MAPPING_COLUMNS.contains(&"property"));
+        assert!(wikidata::DISCOGS_MAPPING_COLUMNS.contains(&"discogs_id"));
+    }
+
+    #[test]
+    fn wikidata_influence_table() {
+        assert!(wikidata::INFLUENCE_COLUMNS.contains(&"source_qid"));
+        assert!(wikidata::INFLUENCE_COLUMNS.contains(&"target_qid"));
+    }
+
+    #[test]
+    fn wikidata_entity_alias_table() {
+        assert!(wikidata::ENTITY_ALIAS_COLUMNS.contains(&"qid"));
+        assert!(wikidata::ENTITY_ALIAS_COLUMNS.contains(&"alias"));
+    }
+
+    // -- MusicBrainz --
+
+    #[test]
+    fn musicbrainz_all_tables_count() {
+        // mb_area_type, mb_gender, mb_tag, mb_area, mb_country_area,
+        // mb_artist, mb_artist_alias, mb_artist_tag, mb_artist_credit,
+        // mb_artist_credit_name, mb_release_group, mb_recording, mb_medium, mb_track
+        assert_eq!(musicbrainz::ALL_TABLES.len(), 14);
+    }
+
+    #[test]
+    fn musicbrainz_artist_table() {
+        assert_eq!(musicbrainz::MB_ARTIST_TABLE, "mb_artist");
+        assert!(musicbrainz::MB_ARTIST_COLUMNS.contains(&"name"));
+        assert!(musicbrainz::MB_ARTIST_COLUMNS.contains(&"sort_name"));
+        assert!(musicbrainz::MB_ARTIST_COLUMNS.contains(&"comment"));
+    }
+
+    #[test]
+    fn musicbrainz_recording_table() {
+        assert_eq!(musicbrainz::MB_RECORDING_TABLE, "mb_recording");
+        assert!(musicbrainz::MB_RECORDING_COLUMNS.contains(&"gid"));
+        assert!(musicbrainz::MB_RECORDING_COLUMNS.contains(&"length"));
+    }
+
+    #[test]
+    fn musicbrainz_track_table() {
+        assert_eq!(musicbrainz::MB_TRACK_TABLE, "mb_track");
+        assert!(musicbrainz::MB_TRACK_COLUMNS.contains(&"recording"));
+        assert!(musicbrainz::MB_TRACK_COLUMNS.contains(&"medium"));
+    }
+
+    #[test]
+    fn musicbrainz_country_area_table() {
+        assert_eq!(musicbrainz::MB_COUNTRY_AREA_TABLE, "mb_country_area");
+        assert!(musicbrainz::MB_COUNTRY_AREA_COLUMNS.contains(&"area"));
+    }
+}

--- a/wxyc-etl/src/schema/mod.rs
+++ b/wxyc-etl/src/schema/mod.rs
@@ -1,0 +1,1 @@
+//! schema module — see implementation plan for details.

--- a/wxyc-etl/src/schema/musicbrainz.rs
+++ b/wxyc-etl/src/schema/musicbrainz.rs
@@ -1,0 +1,94 @@
+//! MusicBrainz-cache table and column constants.
+//!
+//! Matches the PostgreSQL schema in `musicbrainz-cache/schema/create_database.sql`.
+
+pub const MB_AREA_TYPE_TABLE: &str = "mb_area_type";
+pub const MB_AREA_TYPE_COLUMNS: &[&str] = &["id", "name"];
+
+pub const MB_GENDER_TABLE: &str = "mb_gender";
+pub const MB_GENDER_COLUMNS: &[&str] = &["id", "name"];
+
+pub const MB_TAG_TABLE: &str = "mb_tag";
+pub const MB_TAG_COLUMNS: &[&str] = &["id", "name"];
+
+pub const MB_AREA_TABLE: &str = "mb_area";
+pub const MB_AREA_COLUMNS: &[&str] = &["id", "name", "type"];
+
+pub const MB_COUNTRY_AREA_TABLE: &str = "mb_country_area";
+pub const MB_COUNTRY_AREA_COLUMNS: &[&str] = &["area"];
+
+pub const MB_ARTIST_TABLE: &str = "mb_artist";
+pub const MB_ARTIST_COLUMNS: &[&str] = &[
+    "id",
+    "name",
+    "sort_name",
+    "type",
+    "area",
+    "gender",
+    "begin_area",
+    "comment",
+];
+
+pub const MB_ARTIST_ALIAS_TABLE: &str = "mb_artist_alias";
+pub const MB_ARTIST_ALIAS_COLUMNS: &[&str] = &[
+    "id",
+    "artist",
+    "name",
+    "sort_name",
+    "locale",
+    "type",
+    "primary_for_locale",
+];
+
+pub const MB_ARTIST_TAG_TABLE: &str = "mb_artist_tag";
+pub const MB_ARTIST_TAG_COLUMNS: &[&str] = &["artist", "tag", "count"];
+
+pub const MB_ARTIST_CREDIT_TABLE: &str = "mb_artist_credit";
+pub const MB_ARTIST_CREDIT_COLUMNS: &[&str] = &["id", "name", "artist_count"];
+
+pub const MB_ARTIST_CREDIT_NAME_TABLE: &str = "mb_artist_credit_name";
+pub const MB_ARTIST_CREDIT_NAME_COLUMNS: &[&str] = &[
+    "artist_credit",
+    "position",
+    "artist",
+    "name",
+    "join_phrase",
+];
+
+pub const MB_RELEASE_GROUP_TABLE: &str = "mb_release_group";
+pub const MB_RELEASE_GROUP_COLUMNS: &[&str] = &["id", "name", "artist_credit", "type"];
+
+pub const MB_RECORDING_TABLE: &str = "mb_recording";
+pub const MB_RECORDING_COLUMNS: &[&str] = &["id", "gid", "name", "artist_credit", "length"];
+
+pub const MB_MEDIUM_TABLE: &str = "mb_medium";
+pub const MB_MEDIUM_COLUMNS: &[&str] = &["id", "release", "position", "format"];
+
+pub const MB_TRACK_TABLE: &str = "mb_track";
+pub const MB_TRACK_COLUMNS: &[&str] = &[
+    "id",
+    "recording",
+    "medium",
+    "position",
+    "name",
+    "artist_credit",
+    "length",
+];
+
+/// All table names in the musicbrainz-cache schema.
+pub const ALL_TABLES: &[&str] = &[
+    MB_AREA_TYPE_TABLE,
+    MB_GENDER_TABLE,
+    MB_TAG_TABLE,
+    MB_AREA_TABLE,
+    MB_COUNTRY_AREA_TABLE,
+    MB_ARTIST_TABLE,
+    MB_ARTIST_ALIAS_TABLE,
+    MB_ARTIST_TAG_TABLE,
+    MB_ARTIST_CREDIT_TABLE,
+    MB_ARTIST_CREDIT_NAME_TABLE,
+    MB_RELEASE_GROUP_TABLE,
+    MB_RECORDING_TABLE,
+    MB_MEDIUM_TABLE,
+    MB_TRACK_TABLE,
+];

--- a/wxyc-etl/src/schema/wikidata.rs
+++ b/wxyc-etl/src/schema/wikidata.rs
@@ -1,0 +1,40 @@
+//! Wikidata-cache table and column constants.
+//!
+//! Matches the schema defined in the 6b plan
+//! (`plans/phase-6-etl-conversions/6b-wikidata-cache-import.md`).
+
+pub const ENTITY_TABLE: &str = "entity";
+pub const ENTITY_COLUMNS: &[&str] = &["qid", "label", "description", "entity_type"];
+
+pub const DISCOGS_MAPPING_TABLE: &str = "discogs_mapping";
+pub const DISCOGS_MAPPING_COLUMNS: &[&str] = &["qid", "property", "discogs_id"];
+
+pub const INFLUENCE_TABLE: &str = "influence";
+pub const INFLUENCE_COLUMNS: &[&str] = &["source_qid", "target_qid"];
+
+pub const GENRE_TABLE: &str = "genre";
+pub const GENRE_COLUMNS: &[&str] = &["entity_qid", "genre_qid"];
+
+pub const RECORD_LABEL_TABLE: &str = "record_label";
+pub const RECORD_LABEL_COLUMNS: &[&str] = &["artist_qid", "label_qid"];
+
+pub const LABEL_HIERARCHY_TABLE: &str = "label_hierarchy";
+pub const LABEL_HIERARCHY_COLUMNS: &[&str] = &["child_qid", "parent_qid"];
+
+pub const ENTITY_ALIAS_TABLE: &str = "entity_alias";
+pub const ENTITY_ALIAS_COLUMNS: &[&str] = &["qid", "alias"];
+
+pub const OCCUPATION_TABLE: &str = "occupation";
+pub const OCCUPATION_COLUMNS: &[&str] = &["entity_qid", "occupation_qid"];
+
+/// All table names in the wikidata-cache schema.
+pub const ALL_TABLES: &[&str] = &[
+    ENTITY_TABLE,
+    DISCOGS_MAPPING_TABLE,
+    INFLUENCE_TABLE,
+    GENRE_TABLE,
+    RECORD_LABEL_TABLE,
+    LABEL_HIERARCHY_TABLE,
+    ENTITY_ALIAS_TABLE,
+    OCCUPATION_TABLE,
+];

--- a/wxyc-etl/src/sqlite/mod.rs
+++ b/wxyc-etl/src/sqlite/mod.rs
@@ -1,0 +1,1 @@
+//! sqlite module — see implementation plan for details.

--- a/wxyc-etl/src/sqlite/mod.rs
+++ b/wxyc-etl/src/sqlite/mod.rs
@@ -1,1 +1,177 @@
-//! sqlite module — see implementation plan for details.
+//! Batch-buffered SQLite writer with FTS5 full-text search support.
+//!
+//! Ported from `discogs-xml-converter/src/sqlite_output.rs`. Provides a generic
+//! writer that applies performance pragmas, supports transaction-wrapped batch
+//! inserts, and can build FTS5 virtual tables.
+
+mod writer;
+
+pub use writer::{SqliteWriter, SqliteWriterConfig};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_writer(dir: &std::path::Path, batch_size: usize) -> SqliteWriter {
+        let config = SqliteWriterConfig {
+            db_path: dir.join("test.db"),
+            batch_size,
+        };
+        SqliteWriter::new(config).unwrap()
+    }
+
+    #[test]
+    fn applies_performance_pragmas() {
+        let dir = tempfile::tempdir().unwrap();
+        let writer = make_writer(dir.path(), 100);
+
+        let journal: String = writer
+            .conn()
+            .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(journal.to_lowercase(), "wal");
+
+        let sync: i64 = writer
+            .conn()
+            .query_row("PRAGMA synchronous", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(sync, 1); // NORMAL = 1
+
+        let cache: i64 = writer
+            .conn()
+            .query_row("PRAGMA cache_size", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(cache, -256000);
+
+        let temp: i64 = writer
+            .conn()
+            .query_row("PRAGMA temp_store", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(temp, 2); // MEMORY = 2
+    }
+
+    #[test]
+    fn execute_ddl_creates_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let writer = make_writer(dir.path(), 100);
+        writer
+            .execute_ddl("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)")
+            .unwrap();
+
+        let count: i64 = writer
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='test'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn batch_insert_and_flush() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut writer = make_writer(dir.path(), 100);
+        writer
+            .execute_ddl("CREATE TABLE releases (release_id INTEGER PRIMARY KEY, artist TEXT, title TEXT)")
+            .unwrap();
+
+        writer
+            .insert(
+                "INSERT INTO releases (release_id, artist, title) VALUES (?1, ?2, ?3)",
+                &[&1i64 as &dyn rusqlite::types::ToSql, &"Autechre", &"Confield"],
+            )
+            .unwrap();
+        writer
+            .insert(
+                "INSERT INTO releases (release_id, artist, title) VALUES (?1, ?2, ?3)",
+                &[&2i64 as &dyn rusqlite::types::ToSql, &"Stereolab", &"Aluminum Tunes"],
+            )
+            .unwrap();
+        writer.flush_batch().unwrap();
+
+        let count: i64 = writer
+            .conn()
+            .query_row("SELECT COUNT(*) FROM releases", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 2);
+        assert_eq!(writer.total_written(), 2);
+    }
+
+    #[test]
+    fn auto_flush_at_batch_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut writer = make_writer(dir.path(), 2);
+        writer
+            .execute_ddl("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        writer
+            .insert("INSERT INTO t (id) VALUES (?1)", &[&1i64 as &dyn rusqlite::types::ToSql])
+            .unwrap();
+        writer
+            .insert("INSERT INTO t (id) VALUES (?1)", &[&2i64 as &dyn rusqlite::types::ToSql])
+            .unwrap();
+        // batch_size=2, should auto-flush after 2nd insert
+        assert_eq!(writer.total_written(), 2);
+
+        // 3rd insert starts a new batch
+        writer
+            .insert("INSERT INTO t (id) VALUES (?1)", &[&3i64 as &dyn rusqlite::types::ToSql])
+            .unwrap();
+        writer.flush_batch().unwrap();
+        assert_eq!(writer.total_written(), 3);
+    }
+
+    #[test]
+    fn fts5_lifecycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut writer = make_writer(dir.path(), 100);
+        writer
+            .execute_ddl(
+                "CREATE TABLE releases (
+                    release_id INTEGER PRIMARY KEY,
+                    artist TEXT NOT NULL,
+                    title TEXT NOT NULL
+                )",
+            )
+            .unwrap();
+
+        let sql = "INSERT INTO releases (release_id, artist, title) VALUES (?1, ?2, ?3)";
+        writer.insert(sql, &[&1i64 as &dyn rusqlite::types::ToSql, &"Autechre", &"Confield"]).unwrap();
+        writer.insert(sql, &[&2i64 as &dyn rusqlite::types::ToSql, &"Stereolab", &"Aluminum Tunes"]).unwrap();
+        writer.insert(sql, &[&3i64 as &dyn rusqlite::types::ToSql, &"Cat Power", &"Moon Pix"]).unwrap();
+        writer.flush_batch().unwrap();
+
+        writer
+            .build_fts5_index(
+                "releases_fts",
+                "releases",
+                "release_id",
+                &["artist", "title"],
+                "unicode61 remove_diacritics 2",
+            )
+            .unwrap();
+
+        let count: i64 = writer
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM releases_fts WHERE releases_fts MATCH 'Autechre'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+
+        let count: i64 = writer
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM releases_fts WHERE releases_fts MATCH 'Moon'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+}

--- a/wxyc-etl/src/sqlite/writer.rs
+++ b/wxyc-etl/src/sqlite/writer.rs
@@ -1,0 +1,141 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+
+/// Configuration for a `SqliteWriter`.
+pub struct SqliteWriterConfig {
+    pub db_path: PathBuf,
+    pub batch_size: usize,
+}
+
+/// Batch-buffered SQLite writer with FTS5 support.
+///
+/// Ported from `discogs-xml-converter/src/sqlite_output.rs`. Applies performance
+/// pragmas (WAL, NORMAL sync, 256 MB cache, memory temp store), supports
+/// transaction-wrapped batch inserts, and can build FTS5 virtual tables.
+pub struct SqliteWriter {
+    conn: Connection,
+    batch_size: usize,
+    total_written: usize,
+    in_transaction: bool,
+    batch_count: usize,
+}
+
+impl SqliteWriter {
+    /// Create or replace the database at `config.db_path` and apply performance pragmas.
+    pub fn new(config: SqliteWriterConfig) -> Result<Self> {
+        if config.db_path.exists() {
+            std::fs::remove_file(&config.db_path).with_context(|| {
+                format!(
+                    "removing existing database: {}",
+                    config.db_path.display()
+                )
+            })?;
+        }
+
+        let conn = Connection::open(&config.db_path).with_context(|| {
+            format!("creating SQLite database: {}", config.db_path.display())
+        })?;
+
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = NORMAL;
+             PRAGMA cache_size = -256000;
+             PRAGMA temp_store = MEMORY;",
+        )
+        .context("applying performance pragmas")?;
+
+        Ok(Self {
+            conn,
+            batch_size: config.batch_size,
+            total_written: 0,
+            in_transaction: false,
+            batch_count: 0,
+        })
+    }
+
+    /// Execute schema creation SQL (CREATE TABLE, etc.).
+    pub fn execute_ddl(&self, sql: &str) -> Result<()> {
+        self.conn
+            .execute_batch(sql)
+            .with_context(|| "executing DDL".to_string())
+    }
+
+    /// Return a reference to the underlying connection for direct queries.
+    pub fn conn(&self) -> &Connection {
+        &self.conn
+    }
+
+    /// Begin a batch transaction. Rows inserted via the returned `SqliteBatch`
+    /// accumulate until `flush_batch()` commits them.
+    pub fn begin_batch(&mut self) -> Result<()> {
+        if !self.in_transaction {
+            self.conn
+                .execute_batch("BEGIN TRANSACTION")
+                .context("beginning batch transaction")?;
+            self.in_transaction = true;
+            self.batch_count = 0;
+        }
+        Ok(())
+    }
+
+    /// Insert a row within the current batch. Automatically flushes when
+    /// `batch_size` rows have been inserted.
+    pub fn insert(&mut self, sql: &str, params: &[&dyn rusqlite::types::ToSql]) -> Result<()> {
+        if !self.in_transaction {
+            self.begin_batch()?;
+        }
+        self.conn
+            .execute(sql, params)
+            .with_context(|| "inserting row".to_string())?;
+        self.batch_count += 1;
+
+        if self.batch_count >= self.batch_size {
+            self.flush_batch()?;
+        }
+        Ok(())
+    }
+
+    /// Commit the current batch transaction.
+    pub fn flush_batch(&mut self) -> Result<()> {
+        if self.in_transaction {
+            self.conn
+                .execute_batch("COMMIT")
+                .context("committing batch")?;
+            self.total_written += self.batch_count;
+            self.in_transaction = false;
+            self.batch_count = 0;
+        }
+        Ok(())
+    }
+
+    /// Build an FTS5 virtual table and rebuild its index from a content table.
+    pub fn build_fts5_index(
+        &self,
+        table: &str,
+        content_table: &str,
+        content_rowid: &str,
+        columns: &[&str],
+        tokenizer: &str,
+    ) -> Result<()> {
+        let cols = columns.join(",\n                ");
+        let sql = format!(
+            "CREATE VIRTUAL TABLE {table} USING fts5(
+                {cols},
+                content={content_table},
+                content_rowid={content_rowid},
+                tokenize='{tokenizer}'
+            );
+            INSERT INTO {table}({table}) VALUES('rebuild');",
+        );
+        self.conn
+            .execute_batch(&sql)
+            .with_context(|| format!("building FTS5 index {table}"))
+    }
+
+    /// Return the total number of rows written (across all flushed batches).
+    pub fn total_written(&self) -> usize {
+        self.total_written
+    }
+}

--- a/wxyc-etl/src/state/introspect.rs
+++ b/wxyc-etl/src/state/introspect.rs
@@ -1,0 +1,61 @@
+//! Database introspection for inferring pipeline state.
+//!
+//! Ported from `discogs-cache/lib/db_introspect.py`. These functions inspect a
+//! PostgreSQL database to determine which pipeline steps have already completed.
+
+use anyhow::{Context, Result};
+
+/// Return true if the table exists in the public schema.
+pub fn table_exists(client: &mut postgres::Client, table_name: &str) -> Result<bool> {
+    let row = client
+        .query_one(
+            "SELECT EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_schema = 'public' AND table_name = $1
+            )",
+            &[&table_name],
+        )
+        .context("checking table existence")?;
+    Ok(row.get(0))
+}
+
+/// Return true if the table has at least one row.
+pub fn table_has_rows(client: &mut postgres::Client, table_name: &str) -> Result<bool> {
+    let query = format!("SELECT EXISTS (SELECT 1 FROM {} LIMIT 1)", table_name);
+    let row = client
+        .query_one(&query, &[])
+        .with_context(|| format!("checking if {} has rows", table_name))?;
+    Ok(row.get(0))
+}
+
+/// Return true if the column exists on the table.
+pub fn column_exists(
+    client: &mut postgres::Client,
+    table_name: &str,
+    column_name: &str,
+) -> Result<bool> {
+    let row = client
+        .query_one(
+            "SELECT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = $1 AND column_name = $2
+            )",
+            &[&table_name, &column_name],
+        )
+        .context("checking column existence")?;
+    Ok(row.get(0))
+}
+
+/// Return true if the index exists in the public schema.
+pub fn index_exists(client: &mut postgres::Client, index_name: &str) -> Result<bool> {
+    let row = client
+        .query_one(
+            "SELECT EXISTS (
+                SELECT 1 FROM pg_indexes
+                WHERE schemaname = 'public' AND indexname = $1
+            )",
+            &[&index_name],
+        )
+        .context("checking index existence")?;
+    Ok(row.get(0))
+}

--- a/wxyc-etl/src/state/mod.rs
+++ b/wxyc-etl/src/state/mod.rs
@@ -1,0 +1,1 @@
+//! state module — see implementation plan for details.

--- a/wxyc-etl/src/state/mod.rs
+++ b/wxyc-etl/src/state/mod.rs
@@ -1,1 +1,226 @@
-//! state module — see implementation plan for details.
+//! Pipeline state tracking for resumable ETL runs.
+//!
+//! Ported from `discogs-cache/lib/pipeline_state.py` and `db_introspect.py`.
+//! Tracks step completion in a JSON state file so that a failed pipeline can
+//! be resumed from where it left off.
+
+pub mod introspect;
+mod state;
+
+pub use state::{PipelineState, StepStatus, STEP_NAMES, STATE_VERSION};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_state_creation() {
+        let steps = &["create_schema", "import_csv", "create_indexes"];
+        let state = PipelineState::new("postgresql:///discogs", "/tmp/csv", steps);
+
+        assert_eq!(state.step_status("create_schema"), "pending");
+        assert!(!state.is_completed("create_schema"));
+        assert!(!state.is_completed("import_csv"));
+    }
+
+    #[test]
+    fn mark_completed() {
+        let steps = &["step1", "step2"];
+        let mut state = PipelineState::new("db_url", "csv_dir", steps);
+        state.mark_completed("step1");
+        assert!(state.is_completed("step1"));
+        assert!(!state.is_completed("step2"));
+        assert_eq!(state.step_status("step1"), "completed");
+    }
+
+    #[test]
+    fn mark_failed() {
+        let steps = &["step1"];
+        let mut state = PipelineState::new("db_url", "csv_dir", steps);
+        state.mark_failed("step1", "connection refused");
+        assert_eq!(state.step_status("step1"), "failed");
+        assert_eq!(state.step_error("step1"), Some("connection refused"));
+    }
+
+    #[test]
+    fn step_error_returns_none_for_non_failed() {
+        let steps = &["step1"];
+        let state = PipelineState::new("db_url", "csv_dir", steps);
+        assert_eq!(state.step_error("step1"), None);
+    }
+
+    #[test]
+    fn save_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let steps = &["step1", "step2"];
+        let mut state = PipelineState::new("postgresql:///discogs", "/tmp/csv", steps);
+        state.mark_completed("step1");
+        state.save(&path).unwrap();
+
+        let loaded = PipelineState::load(&path).unwrap();
+        assert!(loaded.is_completed("step1"));
+        assert!(!loaded.is_completed("step2"));
+    }
+
+    #[test]
+    fn save_load_with_failed_step() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let mut state = PipelineState::new("db", "csv", STEP_NAMES);
+        state.mark_completed("create_schema");
+        state.mark_failed("import_csv", "disk full");
+        state.save(&path).unwrap();
+
+        let loaded = PipelineState::load(&path).unwrap();
+        assert!(loaded.is_completed("create_schema"));
+        assert_eq!(loaded.step_status("import_csv"), "failed");
+        assert_eq!(loaded.step_error("import_csv"), Some("disk full"));
+    }
+
+    #[test]
+    fn migrate_v1() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let v1_json = r#"{
+            "version": 1,
+            "database_url": "postgresql:///discogs",
+            "csv_dir": "/tmp/csv",
+            "steps": {
+                "create_schema": {"status": "completed"},
+                "import_csv": {"status": "completed"},
+                "create_indexes": {"status": "pending"},
+                "dedup": {"status": "pending"},
+                "prune": {"status": "pending"},
+                "vacuum": {"status": "pending"}
+            }
+        }"#;
+        std::fs::write(&path, v1_json).unwrap();
+
+        let state = PipelineState::load(&path).unwrap();
+        // V1→V3: import_csv completed implies import_tracks completed
+        assert!(state.is_completed("import_tracks"));
+        assert!(state.is_completed("create_schema"));
+        assert!(state.is_completed("import_csv"));
+        // create_indexes not completed, dedup not completed → create_track_indexes stays pending
+        assert!(!state.is_completed("create_track_indexes"));
+        // vacuum not completed → set_logged stays pending
+        assert!(!state.is_completed("set_logged"));
+    }
+
+    #[test]
+    fn migrate_v1_dedup_completed_infers_track_indexes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let v1_json = r#"{
+            "version": 1,
+            "database_url": "db",
+            "csv_dir": "csv",
+            "steps": {
+                "create_schema": {"status": "completed"},
+                "import_csv": {"status": "completed"},
+                "create_indexes": {"status": "completed"},
+                "dedup": {"status": "completed"},
+                "prune": {"status": "completed"},
+                "vacuum": {"status": "completed"}
+            }
+        }"#;
+        std::fs::write(&path, v1_json).unwrap();
+
+        let state = PipelineState::load(&path).unwrap();
+        assert!(state.is_completed("create_track_indexes"));
+        assert!(state.is_completed("import_tracks"));
+        assert!(state.is_completed("set_logged"));
+    }
+
+    #[test]
+    fn migrate_v2() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let v2_json = r#"{
+            "version": 2,
+            "database_url": "db",
+            "csv_dir": "csv",
+            "steps": {
+                "create_schema": {"status": "completed"},
+                "import_csv": {"status": "completed"},
+                "create_indexes": {"status": "completed"},
+                "dedup": {"status": "completed"},
+                "import_tracks": {"status": "completed"},
+                "create_track_indexes": {"status": "completed"},
+                "prune": {"status": "completed"},
+                "vacuum": {"status": "completed"}
+            }
+        }"#;
+        std::fs::write(&path, v2_json).unwrap();
+
+        let state = PipelineState::load(&path).unwrap();
+        // vacuum completed → set_logged completed
+        assert!(state.is_completed("set_logged"));
+    }
+
+    #[test]
+    fn migrate_v2_vacuum_pending() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let v2_json = r#"{
+            "version": 2,
+            "database_url": "db",
+            "csv_dir": "csv",
+            "steps": {
+                "create_schema": {"status": "completed"},
+                "import_csv": {"status": "pending"},
+                "create_indexes": {"status": "pending"},
+                "dedup": {"status": "pending"},
+                "import_tracks": {"status": "pending"},
+                "create_track_indexes": {"status": "pending"},
+                "prune": {"status": "pending"},
+                "vacuum": {"status": "pending"}
+            }
+        }"#;
+        std::fs::write(&path, v2_json).unwrap();
+
+        let state = PipelineState::load(&path).unwrap();
+        assert!(!state.is_completed("set_logged"));
+    }
+
+    #[test]
+    fn unsupported_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        std::fs::write(&path, r#"{"version": 99}"#).unwrap();
+        assert!(PipelineState::load(&path).is_err());
+    }
+
+    #[test]
+    fn validate_resume_ok() {
+        let steps = &["step1"];
+        let state = PipelineState::new("postgresql:///discogs", "/tmp/csv", steps);
+        assert!(state.validate_resume("postgresql:///discogs", "/tmp/csv").is_ok());
+    }
+
+    #[test]
+    fn validate_resume_db_mismatch() {
+        let steps = &["step1"];
+        let state = PipelineState::new("postgresql:///discogs", "/tmp/csv", steps);
+        assert!(state.validate_resume("postgresql:///other", "/tmp/csv").is_err());
+    }
+
+    #[test]
+    fn validate_resume_csv_dir_mismatch() {
+        let steps = &["step1"];
+        let state = PipelineState::new("postgresql:///discogs", "/tmp/csv", steps);
+        assert!(state.validate_resume("postgresql:///discogs", "/other/csv").is_err());
+    }
+
+    #[test]
+    fn atomic_save_no_leftover_tmp() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let state = PipelineState::new("db", "csv", &["step1"]);
+        state.save(&path).unwrap();
+
+        assert!(path.exists());
+        assert!(!path.with_extension("tmp").exists());
+    }
+}

--- a/wxyc-etl/src/state/state.rs
+++ b/wxyc-etl/src/state/state.rs
@@ -1,0 +1,281 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// Current state file version.
+pub const STATE_VERSION: u32 = 3;
+
+/// Step names for the v3 pipeline.
+pub const STEP_NAMES: &[&str] = &[
+    "create_schema",
+    "import_csv",
+    "create_indexes",
+    "dedup",
+    "import_tracks",
+    "create_track_indexes",
+    "prune",
+    "vacuum",
+    "set_logged",
+];
+
+const V1_STEP_NAMES: &[&str] = &[
+    "create_schema",
+    "import_csv",
+    "create_indexes",
+    "dedup",
+    "prune",
+    "vacuum",
+];
+
+const V2_STEP_NAMES: &[&str] = &[
+    "create_schema",
+    "import_csv",
+    "create_indexes",
+    "dedup",
+    "import_tracks",
+    "create_track_indexes",
+    "prune",
+    "vacuum",
+];
+
+/// Status of a pipeline step.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status")]
+pub enum StepStatus {
+    #[serde(rename = "pending")]
+    Pending,
+    #[serde(rename = "completed")]
+    Completed,
+    #[serde(rename = "failed")]
+    Failed {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+}
+
+/// Tracks step completion status for resumable ETL runs.
+///
+/// Ported from `discogs-cache/lib/pipeline_state.py`. Supports save/load with
+/// atomic writes and version migration from v1 and v2 formats.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PipelineState {
+    version: u32,
+    database_url: String,
+    csv_dir: String,
+    steps: HashMap<String, StepStatus>,
+}
+
+impl PipelineState {
+    /// Create a new state with all steps pending.
+    pub fn new(db_url: &str, csv_dir: &str, steps: &[&str]) -> Self {
+        let mut step_map = HashMap::new();
+        for &step in steps {
+            step_map.insert(step.to_string(), StepStatus::Pending);
+        }
+        Self {
+            version: STATE_VERSION,
+            database_url: db_url.to_string(),
+            csv_dir: csv_dir.to_string(),
+            steps: step_map,
+        }
+    }
+
+    /// Return true if the step has been completed.
+    pub fn is_completed(&self, step: &str) -> bool {
+        matches!(self.steps.get(step), Some(StepStatus::Completed))
+    }
+
+    /// Mark a step as completed.
+    pub fn mark_completed(&mut self, step: &str) {
+        self.steps
+            .insert(step.to_string(), StepStatus::Completed);
+    }
+
+    /// Mark a step as failed with an error message.
+    pub fn mark_failed(&mut self, step: &str, error: &str) {
+        self.steps.insert(
+            step.to_string(),
+            StepStatus::Failed {
+                error: Some(error.to_string()),
+            },
+        );
+    }
+
+    /// Return the status string of a step.
+    pub fn step_status(&self, step: &str) -> &str {
+        match self.steps.get(step) {
+            Some(StepStatus::Pending) => "pending",
+            Some(StepStatus::Completed) => "completed",
+            Some(StepStatus::Failed { .. }) => "failed",
+            None => "unknown",
+        }
+    }
+
+    /// Return the error message for a failed step, or None.
+    pub fn step_error(&self, step: &str) -> Option<&str> {
+        match self.steps.get(step) {
+            Some(StepStatus::Failed { error }) => error.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Raise an error if db_url or csv_dir don't match this state.
+    pub fn validate_resume(&self, db_url: &str, csv_dir: &str) -> Result<()> {
+        if self.database_url != db_url {
+            bail!(
+                "database_url mismatch: state has {:?}, got {:?}",
+                self.database_url,
+                db_url
+            );
+        }
+        if self.csv_dir != csv_dir {
+            bail!(
+                "csv_dir mismatch: state has {:?}, got {:?}",
+                self.csv_dir,
+                csv_dir
+            );
+        }
+        Ok(())
+    }
+
+    /// Write state to a JSON file atomically (write .tmp, then rename).
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let json = serde_json::to_string_pretty(self).context("serializing pipeline state")?;
+        let tmp_path = path.with_extension("tmp");
+        std::fs::write(&tmp_path, format!("{}\n", json))
+            .with_context(|| format!("writing temp state file {}", tmp_path.display()))?;
+        std::fs::rename(&tmp_path, path)
+            .with_context(|| format!("renaming {} to {}", tmp_path.display(), path.display()))?;
+        Ok(())
+    }
+
+    /// Load state from a JSON file with version migration support.
+    pub fn load(path: &Path) -> Result<Self> {
+        let text =
+            std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+        let raw: serde_json::Value =
+            serde_json::from_str(&text).context("parsing state JSON")?;
+
+        let version = raw
+            .get("version")
+            .and_then(|v| v.as_u64())
+            .map(|v| v as u32);
+
+        match version {
+            Some(1) => Self::migrate_v1(&raw),
+            Some(2) => Self::migrate_v2(&raw),
+            Some(STATE_VERSION) => Self::load_v3(&raw),
+            Some(v) => bail!("Unsupported state file version {} (expected {})", v, STATE_VERSION),
+            None => bail!("Missing version field in state file"),
+        }
+    }
+
+    fn load_v3(raw: &serde_json::Value) -> Result<Self> {
+        let db_url = raw["database_url"].as_str().context("missing database_url")?;
+        let csv_dir = raw["csv_dir"].as_str().context("missing csv_dir")?;
+        let steps_val = raw.get("steps").context("missing steps")?;
+        let steps_map = steps_val
+            .as_object()
+            .context("steps must be an object")?;
+
+        let step_names: Vec<&str> = steps_map.keys().map(|k| k.as_str()).collect();
+        let mut state = Self::new(db_url, csv_dir, &step_names);
+        Self::copy_steps(&mut state, steps_val, &step_names);
+        Ok(state)
+    }
+
+    /// Migrate a v1 state file to v3 format.
+    ///
+    /// V2 adds import_tracks and create_track_indexes between dedup and prune.
+    /// V3 adds set_logged after vacuum.
+    ///
+    /// Migration rules:
+    /// - All v1 steps map directly to their v3 equivalents
+    /// - import_csv completed → import_tracks completed (v1 imported tracks as part of import_csv)
+    /// - dedup or create_indexes completed → create_track_indexes completed
+    /// - vacuum completed → set_logged completed (v1 used LOGGED tables throughout)
+    fn migrate_v1(raw: &serde_json::Value) -> Result<Self> {
+        let db_url = raw["database_url"].as_str().context("missing database_url")?;
+        let csv_dir = raw["csv_dir"].as_str().context("missing csv_dir")?;
+        let steps_val = raw.get("steps").context("missing steps")?;
+
+        let mut state = Self::new(db_url, csv_dir, STEP_NAMES);
+        Self::copy_steps(&mut state, steps_val, V1_STEP_NAMES);
+
+        // Infer import_tracks from import_csv
+        if Self::step_is_completed(steps_val, "import_csv") {
+            state.mark_completed("import_tracks");
+        }
+
+        // Infer create_track_indexes from dedup or create_indexes
+        if Self::step_is_completed(steps_val, "dedup")
+            || Self::step_is_completed(steps_val, "create_indexes")
+        {
+            state.mark_completed("create_track_indexes");
+        }
+
+        // Infer set_logged from vacuum
+        if Self::step_is_completed(steps_val, "vacuum") {
+            state.mark_completed("set_logged");
+        }
+
+        Ok(state)
+    }
+
+    /// Migrate a v2 state file to v3 format.
+    ///
+    /// V3 adds set_logged after vacuum.
+    ///
+    /// Migration rules:
+    /// - All v2 steps map directly to their v3 equivalents
+    /// - vacuum completed → set_logged completed (v2 used LOGGED tables throughout)
+    fn migrate_v2(raw: &serde_json::Value) -> Result<Self> {
+        let db_url = raw["database_url"].as_str().context("missing database_url")?;
+        let csv_dir = raw["csv_dir"].as_str().context("missing csv_dir")?;
+        let steps_val = raw.get("steps").context("missing steps")?;
+
+        let mut state = Self::new(db_url, csv_dir, STEP_NAMES);
+        Self::copy_steps(&mut state, steps_val, V2_STEP_NAMES);
+
+        // Infer set_logged from vacuum
+        if Self::step_is_completed(steps_val, "vacuum") {
+            state.mark_completed("set_logged");
+        }
+
+        Ok(state)
+    }
+
+    fn copy_steps(state: &mut Self, steps_val: &serde_json::Value, step_names: &[&str]) {
+        for &name in step_names {
+            if let Some(step_obj) = steps_val.get(name) {
+                if let Some(status) = step_obj.get("status").and_then(|s| s.as_str()) {
+                    match status {
+                        "completed" => {
+                            state.steps.insert(name.to_string(), StepStatus::Completed);
+                        }
+                        "failed" => {
+                            let error = step_obj
+                                .get("error")
+                                .and_then(|e| e.as_str())
+                                .map(|s| s.to_string());
+                            state
+                                .steps
+                                .insert(name.to_string(), StepStatus::Failed { error });
+                        }
+                        _ => {} // keep as pending
+                    }
+                }
+            }
+        }
+    }
+
+    fn step_is_completed(steps_val: &serde_json::Value, name: &str) -> bool {
+        steps_val
+            .get(name)
+            .and_then(|s| s.get("status"))
+            .and_then(|s| s.as_str())
+            == Some("completed")
+    }
+}

--- a/wxyc-etl/src/text/mod.rs
+++ b/wxyc-etl/src/text/mod.rs
@@ -1,0 +1,1 @@
+//! text module — see implementation plan for details.


### PR DESCRIPTION
Closes #4

## Summary

- **csv_writer**: `CsvFileSpec` + `MultiCsvWriter` — manages N csv::Writer instances with pre-written headers, indexed and named access. Ported from `discogs-xml-converter/src/writer.rs` and `wikidata-json-filter/src/writer.rs`.
- **sqlite**: `SqliteWriter` with performance pragmas (WAL, NORMAL sync, 256MB cache, memory temp store), transaction-wrapped batch inserts with auto-flush, and FTS5 virtual table creation. Ported from `discogs-xml-converter/src/sqlite_output.rs`.
- **state**: `PipelineState` with save/load (atomic tmp+rename), v1/v2/v3 version migration, resume validation. `introspect` module with PostgreSQL `information_schema` queries for state inference. Ported from `discogs-cache/lib/pipeline_state.py` and `db_introspect.py`.
- **import**: `ColumnMapping` (unified from discogs-cache `TableConfig` and musicbrainz-cache `TableSpec`) + `ImportDedupSet` for in-memory deduplication by composite key.
- **schema**: Constants for all five database schemas — library.db (SQLite DDL + FTS5), discogs-cache (13 tables), entity store (identity + reconciliation_log DDL), wikidata-cache (8 tables), musicbrainz-cache (14 tables). All constants match SQL DDL in source repos.

## Test plan

- [x] 54 unit tests pass (`cargo test -p wxyc-etl`)
- [x] CSV: file creation with headers, nested directory creation, write+flush, named access
- [x] SQLite: pragma verification, DDL execution, batch insert/flush, auto-flush at batch_size, FTS5 lifecycle with MATCH queries
- [x] State: creation, mark completed/failed, save/load roundtrip, v1→v3 migration, v2→v3 migration, validate_resume mismatch detection, atomic save (no leftover .tmp)
- [x] Import: column mapping with transforms, unique key indices, dedup set insert/duplicate detection
- [x] Schema: table names, column lists, DDL content verification for all 5 schema domains
- [ ] Introspection functions require PostgreSQL (gated behind `TEST_DATABASE_URL`)