### PR TITLE
Standardize pytest markers in wxyc-etl-python pyproject.toml

### DIFF
--- a/wxyc-etl-python/pyproject.toml
+++ b/wxyc-etl-python/pyproject.toml
@@ -15,5 +15,13 @@ features = ["pyo3/extension-module"]
 
 [tool.pytest.ini_options]
 markers = [
+    "unit: pure logic tests, no external dependencies",
+    "postgres: needs PostgreSQL (gated by DATABASE_URL_TEST)",
+    "integration: needs external service or fixture data",
+    "e2e: full pipeline end-to-end test",
+    "parity: old vs new implementation comparison",
+    "slow: marks tests as slow",
     "perf: performance benchmarks (require release build)",
 ]
+addopts = "-m 'not integration and not postgres and not e2e and not parity and not slow and not perf'"
+testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Adds the canonical 6-marker WXYC ETL block (\`unit\`, \`postgres\`, \`integration\`, \`e2e\`, \`parity\`, \`slow\`) defined in the org-local \`plans/test-patterns.md\`, plus the existing repo-specific \`perf\` marker.

Adds \`addopts\` so \`pytest\` with no arguments runs only unit tests, matching the convention used by the other ETL repos (discogs-etl, library-metadata-lookup, semantic-index, wxyc-catalog). Previously, \`perf\` was the only declared marker and there was no \`addopts\`, so \`pytest\` ran every collected test by default and \`pytest -m unit\` failed with an unknown-marker warning.

Part of #23 (test pattern standardization across ETL repos). This is the wxyc-etl-python sub-PR (PR-A3 of the planned chain).

## Test plan

- [x] \`pytest --markers\` lists all 7 markers (6 canonical + \`perf\`)
- [x] \`pytest -m unit --co\` no longer reports an unknown-marker warning
- [x] \`pytest -m perf --co\` still works (existing tests in \`tests/test_performance.py\` opt in)
- [ ] CI green