### PR TITLE
Replace mainstream-artist test fixtures with canonical WXYC names

### DIFF
--- a/wxyc-etl-python/tests/test_performance.py
+++ b/wxyc-etl-python/tests/test_performance.py
@@ -17,7 +17,7 @@ perf = pytest.mark.perf
 @perf
 def test_batch_normalize_performance():
     """100K normalizations should complete in under 200ms (release build)."""
-    names = ["Björk"] * 100_000
+    names = ["Nilüfer Yanya"] * 100_000
     start = time.time()
     results = text.batch_normalize(names)
     elapsed = time.time() - start
@@ -30,7 +30,7 @@ def test_normalize_individual_calls():
     """100K individual normalize calls should complete in under 500ms."""
     start = time.time()
     for _ in range(100_000):
-        text.normalize_artist_name("Björk")
+        text.normalize_artist_name("Nilüfer Yanya")
     elapsed = time.time() - start
     assert elapsed < 0.5, f"100K normalize calls took {elapsed:.3f}s"
 
@@ -38,7 +38,7 @@ def test_normalize_individual_calls():
 @perf
 def test_batch_normalize_million():
     """1M normalizations via batch should complete in under 2s (release build)."""
-    names = ["Sigur Rós"] * 1_000_000
+    names = ["Csillagrablók"] * 1_000_000
     start = time.time()
     results = text.batch_normalize(names)
     elapsed = time.time() - start

--- a/wxyc-etl-python/tests/test_text.py
+++ b/wxyc-etl-python/tests/test_text.py
@@ -10,17 +10,14 @@ from wxyc_etl import text
 @pytest.mark.parametrize(
     "input_name,expected",
     [
-        ("Radiohead", "radiohead"),
-        ("  Radiohead  ", "radiohead"),
-        ("RADIOHEAD", "radiohead"),
+        ("Stereolab", "stereolab"),
+        ("  Stereolab  ", "stereolab"),
+        ("STEREOLAB", "stereolab"),
         ("  Mixed Case  ", "mixed case"),
         ("", ""),
-        ("Björk", "bjork"),
-        ("Sigur Rós", "sigur ros"),
-        ("Motörhead", "motorhead"),
-        ("Hüsker Dü", "husker du"),
-        ("Café Tacvba", "cafe tacvba"),
-        ("Zoé", "zoe"),
+        ("Nilüfer Yanya", "nilufer yanya"),
+        ("Csillagrablók", "csillagrablok"),
+        ("Hermanos Gutiérrez", "hermanos gutierrez"),
     ],
     ids=[
         "lowercase",
@@ -28,12 +25,9 @@ from wxyc_etl import text
         "all_caps",
         "mixed_case_strip",
         "empty",
-        "bjork",
-        "sigur_ros",
-        "motorhead",
-        "husker_du",
-        "cafe_tacvba",
-        "zoe",
+        "nilufer_yanya",
+        "csillagrablok",
+        "hermanos_gutierrez",
     ],
 )
 def test_normalize_artist_name(input_name, expected):
@@ -51,9 +45,9 @@ def test_normalize_artist_name_none():
 @pytest.mark.parametrize(
     "input_str,expected",
     [
-        ("Björk", "Bjork"),
-        ("  Café  ", "  Cafe  "),
-        ("Radiohead", "Radiohead"),
+        ("Nilüfer Yanya", "Nilufer Yanya"),
+        ("  Hermanos Gutiérrez  ", "  Hermanos Gutierrez  "),
+        ("Stereolab", "Stereolab"),
         ("", ""),
     ],
 )
@@ -65,8 +59,8 @@ def test_strip_diacritics(input_str, expected):
 
 
 def test_batch_normalize():
-    results = text.batch_normalize(["Björk", "Radiohead", "Sigur Rós"])
-    assert results == ["bjork", "radiohead", "sigur ros"]
+    results = text.batch_normalize(["Nilüfer Yanya", "Stereolab", "Csillagrablók"])
+    assert results == ["nilufer yanya", "stereolab", "csillagrablok"]
 
 
 def test_batch_normalize_empty():
@@ -96,8 +90,8 @@ def test_is_compilation_artist(name, expected):
 
 
 def test_split_artist_name_comma():
-    result = text.split_artist_name("Mike Vainio, Ryoji, Alva Noto")
-    assert result == ["Mike Vainio", "Ryoji", "Alva Noto"]
+    result = text.split_artist_name("Yo La Tengo, Stereolab, Autechre")
+    assert result == ["Yo La Tengo", "Stereolab", "Autechre"]
 
 
 def test_split_artist_name_slash():
@@ -115,6 +109,8 @@ def test_split_artist_name_ampersand_no_context():
 
 
 def test_split_artist_name_numeric_guard():
+    # Non-canonical name kept as a guard test input: leading "<digits>," should
+    # not split on the comma.
     assert text.split_artist_name("10,000 Maniacs") is None
 
 
@@ -132,7 +128,7 @@ def test_split_artist_name_contextual_with_known():
 
 
 def test_split_artist_name_contextual_no_known():
-    result = text.split_artist_name_contextual("Simon & Garfunkel", set())
+    result = text.split_artist_name_contextual("Yo La Tengo & Animal Collective", set())
     assert result is None
 
 

--- a/wxyc-etl/src/fuzzy/batch.rs
+++ b/wxyc-etl/src/fuzzy/batch.rs
@@ -135,8 +135,8 @@ mod tests {
 
     #[test]
     fn test_batch_filter_artists_diacritics() {
-        let library_set: HashSet<String> = vec!["bjork".to_string()].into_iter().collect();
-        let names = vec!["Björk".to_string(), "bjork".to_string()];
+        let library_set: HashSet<String> = vec!["nilufer yanya".to_string()].into_iter().collect();
+        let names = vec!["Nilüfer Yanya".to_string(), "nilüfer yanya".to_string()];
         let results = batch_filter_artists(&names, &library_set);
         assert_eq!(results, vec![true, true]);
     }

--- a/wxyc-etl/src/text/batch.rs
+++ b/wxyc-etl/src/text/batch.rs
@@ -29,10 +29,14 @@ mod tests {
 
     #[test]
     fn test_batch_normalize_basic() {
-        let names = vec!["Björk".into(), "Radiohead".into(), "Sigur Rós".into()];
+        let names = vec![
+            "Nilüfer Yanya".into(),
+            "Stereolab".into(),
+            "Csillagrablók".into(),
+        ];
         assert_eq!(
             batch_normalize(&names),
-            vec!["bjork", "radiohead", "sigur ros"]
+            vec!["nilufer yanya", "stereolab", "csillagrablok"]
         );
     }
 
@@ -46,13 +50,13 @@ mod tests {
     fn test_batch_filter_matches() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("artists.txt");
-        fs::write(&path, "Radiohead\nBjörk\n").unwrap();
+        fs::write(&path, "Stereolab\nNilüfer Yanya\n").unwrap();
 
         let filter = super::super::filter::ArtistFilter::from_file(&path).unwrap();
         let names = vec![
-            "Radiohead".into(),
+            "Stereolab".into(),
             "Unknown".into(),
-            "Björk".into(),
+            "Nilüfer Yanya".into(),
             "Cat Power".into(),
         ];
         assert_eq!(
@@ -65,7 +69,7 @@ mod tests {
     fn test_batch_filter_empty() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("artists.txt");
-        fs::write(&path, "Radiohead\n").unwrap();
+        fs::write(&path, "Stereolab\n").unwrap();
 
         let filter = super::super::filter::ArtistFilter::from_file(&path).unwrap();
         let names: Vec<String> = vec![];

--- a/wxyc-etl/src/text/filter.rs
+++ b/wxyc-etl/src/text/filter.rs
@@ -221,13 +221,13 @@ mod tests {
     fn test_artist_filter_from_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("artists.txt");
-        fs::write(&path, "Radiohead\nBjörk\n  Joy Division  \n\n").unwrap();
+        fs::write(&path, "Stereolab\nNilüfer Yanya\n  Yo La Tengo  \n\n").unwrap();
 
         let filter = ArtistFilter::from_file(&path).unwrap();
         assert_eq!(filter.len(), 3);
-        assert!(filter.matches_any(["Radiohead"].iter().copied()));
-        assert!(filter.matches_any(["Björk"].iter().copied()));
-        assert!(filter.matches_any(["joy division"].iter().copied()));
+        assert!(filter.matches_any(["Stereolab"].iter().copied()));
+        assert!(filter.matches_any(["Nilüfer Yanya"].iter().copied()));
+        assert!(filter.matches_any(["yo la tengo"].iter().copied()));
         assert!(!filter.matches_any(["Unknown Artist"].iter().copied()));
     }
 
@@ -235,10 +235,10 @@ mod tests {
     fn test_artist_filter_matches_any() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("artists.txt");
-        fs::write(&path, "Radiohead\nBjörk\n").unwrap();
+        fs::write(&path, "Stereolab\nNilüfer Yanya\n").unwrap();
 
         let filter = ArtistFilter::from_file(&path).unwrap();
-        assert!(filter.matches_any(["Unknown", "Radiohead"].iter().copied()));
+        assert!(filter.matches_any(["Unknown", "Stereolab"].iter().copied()));
         assert!(!filter.matches_any(["Unknown", "Other"].iter().copied()));
     }
 
@@ -247,16 +247,16 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
 
         let lib_path = dir.path().join("artists.txt");
-        fs::write(&lib_path, "Puff Daddy\n").unwrap();
+        fs::write(&lib_path, "Madlib\n").unwrap();
 
         let alias_path = dir.path().join("artist_alias.csv");
         fs::write(
             &alias_path,
             "artist_id,artist_name,alias_name\n\
-             123,P. Diddy,P Diddy\n\
-             123,P. Diddy,Puff Daddy\n\
-             123,P. Diddy,Sean Combs\n\
-             123,P. Diddy,Diddy\n",
+             123,Madlib,Quasimoto\n\
+             123,Madlib,Madlib\n\
+             123,Madlib,Lord Quas\n\
+             123,Madlib,DJ Rels\n",
         )
         .unwrap();
 
@@ -266,8 +266,8 @@ mod tests {
         assert!(filter.has_aliases());
 
         // "P. Diddy" doesn't match directly, but alias lookup finds "Puff Daddy"
-        assert!(!filter.matches_any(["P. Diddy"].iter().copied()));
-        assert!(filter.matches_any_with_ids(&[(123, "P. Diddy")]));
+        assert!(!filter.matches_any(["Quasimoto"].iter().copied()));
+        assert!(filter.matches_any_with_ids(&[(123, "Quasimoto")]));
 
         // Unknown artist doesn't match
         assert!(!filter.matches_any_with_ids(&[(999, "Unknown")]));
@@ -277,10 +277,10 @@ mod tests {
     fn test_matches_any_with_ids_canonical_name_still_works() {
         let dir = tempfile::tempdir().unwrap();
         let lib_path = dir.path().join("artists.txt");
-        fs::write(&lib_path, "Radiohead\n").unwrap();
+        fs::write(&lib_path, "Stereolab\n").unwrap();
 
         let filter = ArtistFilter::from_file(&lib_path).unwrap();
-        assert!(filter.matches_any_with_ids(&[(300, "Radiohead")]));
+        assert!(filter.matches_any_with_ids(&[(300, "Stereolab")]));
         assert!(!filter.matches_any_with_ids(&[(300, "Unknown")]));
     }
 }

--- a/wxyc-etl/src/text/normalize.rs
+++ b/wxyc-etl/src/text/normalize.rs
@@ -69,17 +69,17 @@ mod tests {
 
     #[test]
     fn test_normalize_lowercase() {
-        assert_eq!(normalize_artist_name("Radiohead"), "radiohead");
+        assert_eq!(normalize_artist_name("Stereolab"), "stereolab");
     }
 
     #[test]
     fn test_normalize_strip_spaces() {
-        assert_eq!(normalize_artist_name("  Radiohead  "), "radiohead");
+        assert_eq!(normalize_artist_name("  Stereolab  "), "stereolab");
     }
 
     #[test]
     fn test_normalize_all_caps() {
-        assert_eq!(normalize_artist_name("RADIOHEAD"), "radiohead");
+        assert_eq!(normalize_artist_name("STEREOLAB"), "stereolab");
     }
 
     #[test]
@@ -93,13 +93,13 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_bjork() {
-        assert_eq!(normalize_artist_name("Björk"), "bjork");
+    fn test_normalize_nilufer_yanya() {
+        assert_eq!(normalize_artist_name("Nilüfer Yanya"), "nilufer yanya");
     }
 
     #[test]
-    fn test_normalize_sigur_ros() {
-        assert_eq!(normalize_artist_name("Sigur Rós"), "sigur ros");
+    fn test_normalize_csillagrablok() {
+        assert_eq!(normalize_artist_name("Csillagrablók"), "csillagrablok");
     }
 
     #[test]
@@ -113,8 +113,11 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_cafe_tacvba() {
-        assert_eq!(normalize_artist_name("Café Tacvba"), "cafe tacvba");
+    fn test_normalize_hermanos_gutierrez() {
+        assert_eq!(
+            normalize_artist_name("Hermanos Gutiérrez"),
+            "hermanos gutierrez"
+        );
     }
 
     #[test]
@@ -126,34 +129,40 @@ mod tests {
 
     #[test]
     fn test_normalize_trim_no_extra_alloc() {
-        assert_eq!(normalize_artist_name("Radiohead"), "radiohead");
+        assert_eq!(normalize_artist_name("Stereolab"), "stereolab");
     }
 
     #[test]
     fn test_normalize_trim_leading_space() {
-        assert_eq!(normalize_artist_name("  Björk"), "bjork");
+        assert_eq!(normalize_artist_name("  Nilüfer Yanya"), "nilufer yanya");
     }
 
     #[test]
     fn test_normalize_trim_trailing_space() {
-        assert_eq!(normalize_artist_name("Zoé  "), "zoe");
+        assert_eq!(
+            normalize_artist_name("Hermanos Gutiérrez  "),
+            "hermanos gutierrez"
+        );
     }
 
     // --- strip_diacritics: preserves case and whitespace ---
 
     #[test]
     fn test_strip_diacritics_preserves_case() {
-        assert_eq!(strip_diacritics("Björk"), "Bjork");
+        assert_eq!(strip_diacritics("Nilüfer Yanya"), "Nilufer Yanya");
     }
 
     #[test]
     fn test_strip_diacritics_preserves_whitespace() {
-        assert_eq!(strip_diacritics("  Café  "), "  Cafe  ");
+        assert_eq!(
+            strip_diacritics("  Hermanos Gutiérrez  "),
+            "  Hermanos Gutierrez  "
+        );
     }
 
     #[test]
     fn test_strip_diacritics_no_change() {
-        assert_eq!(strip_diacritics("Radiohead"), "Radiohead");
+        assert_eq!(strip_diacritics("Stereolab"), "Stereolab");
     }
 
     #[test]
@@ -165,8 +174,8 @@ mod tests {
 
     #[test]
     fn test_normalize_title_lowercase_and_diacritics() {
-        assert_eq!(normalize_title("Café Tacvba"), "cafe tacvba");
+        assert_eq!(normalize_title("Hermanos Gutiérrez"), "hermanos gutierrez");
         assert_eq!(normalize_title("  Sugar Hill  "), "sugar hill");
-        assert_eq!(normalize_title("OK Computer"), "ok computer");
+        assert_eq!(normalize_title("Aluminum Tunes"), "aluminum tunes");
     }
 }

--- a/wxyc-etl/src/text/split.rs
+++ b/wxyc-etl/src/text/split.rs
@@ -382,10 +382,10 @@ mod tests {
 
     #[test]
     fn test_contextual_known_artists_normalized() {
-        let known: HashSet<String> = ["bjork"].iter().map(|s| s.to_string()).collect();
+        let known: HashSet<String> = ["nilufer yanya"].iter().map(|s| s.to_string()).collect();
         assert_eq!(
-            split_artist_name_contextual("Björk & Thom Yorke", &known),
-            Some(vec!["Björk".into(), "Thom Yorke".into()])
+            split_artist_name_contextual("Nilüfer Yanya & Mary Halvorson", &known),
+            Some(vec!["Nilüfer Yanya".into(), "Mary Halvorson".into()])
         );
     }
 

--- a/wxyc-etl/tests/python_parity.rs
+++ b/wxyc-etl/tests/python_parity.rs
@@ -12,26 +12,22 @@ use wxyc_etl::text::normalize::{normalize_artist_name, normalize_title, strip_di
 use wxyc_etl::text::split::{split_artist_name, split_artist_name_contextual};
 
 /// Edge cases for normalize_artist_name, verified against Python
-/// `filter_csv.py:normalize_artist()`.
+/// `filter_csv.py:normalize_artist()`. Diacritic-bearing artists are drawn
+/// from the canonical pool (`wxycCanonicalArtistNames` in @wxyc/shared).
 #[test]
 fn test_normalize_python_parity() {
     // (input, expected_output) from running Python normalize_artist()
     let cases = [
-        // Basic Latin diacritics
-        ("Björk", "bjork"),
-        ("Sigur Rós", "sigur ros"),
-        ("Motörhead", "motorhead"),
-        ("Hüsker Dü", "husker du"),
-        ("Café Tacvba", "cafe tacvba"),
-        ("Zoé", "zoe"),
+        // Basic Latin diacritics (from the canonical WXYC pool)
+        ("Nilüfer Yanya", "nilufer yanya"),
+        ("Csillagrablók", "csillagrablok"),
+        ("Hermanos Gutiérrez", "hermanos gutierrez"),
         // Case and whitespace
-        ("  RADIOHEAD  ", "radiohead"),
+        ("  STEREOLAB  ", "stereolab"),
         ("", ""),
-        // Multiple diacritics in one name
-        ("José González", "jose gonzalez"),
-        // Combining tilde (ñ decomposes to n + combining tilde)
-        ("Señor Coconut", "senor coconut"),
-        // Polish ł (NFKD doesn't decompose ł — it stays as-is)
+        // Polish ł (NFKD doesn't decompose ł — it stays as-is). Test input
+        // is a generic Polish word, not a WXYC artist; the canonical pool
+        // currently has no ł-bearing names.
         ("Łona", "łona"),
         // Japanese (no decomposition expected)
         ("坂本龍一", "坂本龍一"),
@@ -51,9 +47,9 @@ fn test_normalize_python_parity() {
 #[test]
 fn test_strip_diacritics_python_parity() {
     let cases = [
-        ("Björk", "Bjork"),
-        ("  Café  ", "  Cafe  "),
-        ("SIGUR RÓS", "SIGUR ROS"),
+        ("Nilüfer Yanya", "Nilufer Yanya"),
+        ("  Hermanos Gutiérrez  ", "  Hermanos Gutierrez  "),
+        ("CSILLAGRABLÓK", "CSILLAGRABLOK"),
         ("normal text", "normal text"),
     ];
 
@@ -70,7 +66,7 @@ fn test_strip_diacritics_python_parity() {
 /// Verify normalize_title matches normalize_artist_name.
 #[test]
 fn test_normalize_title_parity() {
-    let inputs = ["OK Computer", "Café Tacvba", "  Sugar Hill  "];
+    let inputs = ["Aluminum Tunes", "Hermanos Gutiérrez", "  Sugar Hill  "];
     for input in &inputs {
         assert_eq!(
             normalize_title(input),
@@ -114,19 +110,22 @@ fn test_compilation_python_parity() {
 /// Verify split_artist_name against Python artist_splitting.py.
 #[test]
 fn test_split_python_parity() {
+    // Multi-artist inputs use canonical WXYC names. Numeric-guard and "and"-guard
+    // inputs ("10,000 Maniacs", "Andy Human and the Reptoids") are kept as
+    // non-canonical strings because they exercise specific algorithm guards.
     let cases: Vec<(&str, Option<Vec<&str>>)> = vec![
         (
-            "Mike Vainio, Ryoji, Alva Noto",
-            Some(vec!["Mike Vainio", "Ryoji", "Alva Noto"]),
+            "Yo La Tengo, Stereolab, Autechre",
+            Some(vec!["Yo La Tengo", "Stereolab", "Autechre"]),
         ),
         (
-            "Mika Vainio + Ryoji Ikeda + Alva Noto",
-            Some(vec!["Mika Vainio", "Ryoji Ikeda", "Alva Noto"]),
+            "Yo La Tengo + Stereolab + Autechre",
+            Some(vec!["Yo La Tengo", "Stereolab", "Autechre"]),
         ),
         ("J Dilla / Jay Dee", Some(vec!["J Dilla", "Jay Dee"])),
         (
-            "Emerson, Lake, and Palmer",
-            Some(vec!["Emerson", "Lake", "Palmer"]),
+            "Stereolab, Autechre, and Aphex Twin",
+            Some(vec!["Stereolab", "Autechre", "Aphex Twin"]),
         ),
         ("10,000 Maniacs", None),
         ("Autechre", None),
@@ -151,23 +150,37 @@ fn test_split_python_parity() {
 /// Verify split_artist_name_contextual against Python.
 #[test]
 fn test_split_contextual_python_parity() {
-    let known: HashSet<String> = ["duke ellington", "john coltrane", "young", "bjork", "god"]
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
+    let known: HashSet<String> = [
+        "duke ellington",
+        "john coltrane",
+        "stereolab",
+        "nilufer yanya",
+        "god",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
 
     let cases: Vec<(&str, Option<Vec<&str>>)> = vec![
         (
             "Duke Ellington & John Coltrane",
             Some(vec!["Duke Ellington", "John Coltrane"]),
         ),
-        ("Simon & Garfunkel", None),
+        ("Yo La Tengo & Animal Collective", None), // neither canonical, neither in known set
         ("J Dilla / Jay Dee", Some(vec!["J Dilla", "Jay Dee"])),
         (
-            "Crosby, Stills, Nash & Young",
-            Some(vec!["Crosby", "Stills", "Nash", "Young"]),
+            "Yo La Tengo, Cat Power, Mary Lattimore & Stereolab",
+            Some(vec![
+                "Yo La Tengo",
+                "Cat Power",
+                "Mary Lattimore",
+                "Stereolab",
+            ]),
         ),
-        ("Björk & Thom Yorke", Some(vec!["Björk", "Thom Yorke"])),
+        (
+            "Nilüfer Yanya & Mary Halvorson",
+            Some(vec!["Nilüfer Yanya", "Mary Halvorson"]),
+        ),
         ("13 & God", Some(vec!["13", "God"])),
     ];
 
@@ -188,10 +201,10 @@ fn test_split_contextual_python_parity() {
 #[test]
 fn test_batch_normalize_parity() {
     let names: Vec<String> = vec![
-        "Björk".into(),
-        "Sigur Rós".into(),
-        "  Radiohead  ".into(),
-        "Café Tacvba".into(),
+        "Nilüfer Yanya".into(),
+        "Csillagrablók".into(),
+        "  Stereolab  ".into(),
+        "Hermanos Gutiérrez".into(),
     ];
 
     let batch_result = batch_normalize(&names);


### PR DESCRIPTION
Closes #36. Depends conceptually on WXYC/wxyc-shared#75 (adds Nilüfer Yanya, Csillagrablók, Hermanos Gutiérrez to the canonical pool); tests run identically without it.

## Summary

Rust unit tests, the `python_parity` integration test, and Python binding tests in `wxyc-etl-python` previously used mainstream stand-ins (Radiohead, Björk, Sigur Rós, Motörhead, Hüsker Dü, Café Tacvba, Zoé, OK Computer, Joy Division, Puff Daddy, Simon & Garfunkel, Crosby/Stills/Nash & Young, Mike Vainio, Emerson/Lake/Palmer, Thom Yorke). Replaces every mainstream / non-canonical artist name with canonical equivalents.

Diacritic coverage is preserved by drawing from the diacritic-bearing canonical names: **Nilüfer Yanya** (ü), **Csillagrablók** (ó), **Hermanos Gutiérrez** (é). The alias test substitutes Puff Daddy + 4 fake aliases with **Madlib** + 3 real aliases (Quasimoto, Lord Quas, DJ Rels). Multi-artist split inputs use canonical 3- and 4-artist combinations (Yo La Tengo / Stereolab / Autechre / Aphex Twin).

Intentionally retained non-canonical inputs: `10,000 Maniacs` and `Andy Human and the Reptoids` (algorithm guards), `Łona` (NFKD non-decomposition), CJK strings (pass-through behavior). The `José González`, `Señor Coconut`, `Motörhead`, `Hüsker Dü`, and `Zoé` cases are dropped — either redundant with the canonical-name coverage or no canonical analogue exists for the specific Unicode shape.

## Test plan

- [x] `cargo test --lib` — 350 passed
- [x] `cargo test --test python_parity` — 7 passed
- [x] Pre-existing `pg_error_tests::test_scanner_panic_does_not_deadlock_writer` flake unrelated to this PR (fails on clean origin/main too)
- [ ] CI passes