### PR TITLE
Restore dropped Unicode test cases now that canonical pool covers ñ and multi-diacritic

### DIFF
--- a/wxyc-etl-python/tests/test_text.py
+++ b/wxyc-etl-python/tests/test_text.py
@@ -18,6 +18,11 @@ from wxyc_etl import text
         ("Nilüfer Yanya", "nilufer yanya"),
         ("Csillagrablók", "csillagrablok"),
         ("Hermanos Gutiérrez", "hermanos gutierrez"),
+        # ñ (combining-tilde decomposition) — canonical from @wxyc/shared#81
+        ("Sonido Dueñez", "sonido duenez"),
+        # Multi-diacritic Turkish — canonical from @wxyc/shared#81. Note:
+        # ı (dotless i) does not decompose under NFKD; only ş is stripped.
+        ("Aşıq Altay", "asıq altay"),
     ],
     ids=[
         "lowercase",
@@ -28,6 +33,8 @@ from wxyc_etl import text
         "nilufer_yanya",
         "csillagrablok",
         "hermanos_gutierrez",
+        "sonido_duenez",
+        "asiq_altay",
     ],
 )
 def test_normalize_artist_name(input_name, expected):

--- a/wxyc-etl/tests/python_parity.rs
+++ b/wxyc-etl/tests/python_parity.rs
@@ -22,6 +22,13 @@ fn test_normalize_python_parity() {
         ("Nilüfer Yanya", "nilufer yanya"),
         ("Csillagrablók", "csillagrablok"),
         ("Hermanos Gutiérrez", "hermanos gutierrez"),
+        // ñ — combining-tilde decomposition path (canonical, added in @wxyc/shared#81)
+        ("Sonido Dueñez", "sonido duenez"),
+        // Multi-diacritic single name — exercises the stripping loop on > 1
+        // combining mark in one input. Aşıq Altay is canonical (added in
+        // @wxyc/shared#81) and has both ş (s + cedilla) and ı (dotless i,
+        // does not decompose under NFKD).
+        ("Aşıq Altay", "asıq altay"),
         // Case and whitespace
         ("  STEREOLAB  ", "stereolab"),
         ("", ""),


### PR DESCRIPTION
Closes #40. Depends on WXYC/wxyc-shared#81 conceptually (adds Sonido Dueñez + Aşıq Altay to the canonical pool); these tests use string literals so they pass regardless.

## Summary

#37 dropped `José González` and `Señor Coconut` from `tests/python_parity.rs` because the canonical pool had no analogue for ñ or multi-diacritic single names. WXYC/wxyc-shared#81 adds **Sonido Dueñez** (ñ) and **Aşıq Altay** (multi-diacritic Turkish ş + ı). Restores both cases in the Rust integration test and adds matching entries to the Python binding test.

The expected output for `Aşıq Altay` is `asıq altay` — `ı` (dotless i) doesn't NFKD-decompose to `i`, so only `ş` is stripped. A code comment notes this.

## Test plan

- [x] `cargo test --test python_parity` — 7 passed
- [x] `cargo test --lib` — 350 passed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets` (with the project's standard allow-list) — clean
- [ ] CI passes (including `python-wheel` job which exercises the new Python parametrize entries)