### PR TITLE
Add reusable CI marker / workflow sync check (closes #42)

### DIFF
--- a/.github/workflows/check-ci-marker-sync.yml
+++ b/.github/workflows/check-ci-marker-sync.yml
@@ -1,0 +1,66 @@
+name: Check CI marker sync
+
+# Reusable workflow that verifies a calling repo's pytest marker scheme stays
+# in sync with its CI workflows. Invoked from sister WXYC repos as:
+#
+#   jobs:
+#     check-ci-marker-sync:
+#       uses: WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main
+#       with:
+#         repo-path: "."           # or "service/" for monorepo subdirs
+#         workflows-dir: ".github/workflows"
+#         tests-dir: "tests"
+#
+# All inputs are optional and default to single-package layout. The job fails
+# if any marker actually used by tests in the repo is excluded by addopts and
+# not explicitly re-selected by any CI pytest invocation.
+
+on:
+  workflow_call:
+    inputs:
+      repo-path:
+        description: "Path within the calling repo containing pyproject.toml"
+        type: string
+        default: "."
+      workflows-dir:
+        description: "Path to .github/workflows within the calling repo"
+        type: string
+        default: ".github/workflows"
+      tests-dir:
+        description: "Path to the test directory within the calling repo"
+        type: string
+        default: "tests"
+      wxyc-etl-ref:
+        description: "Git ref of WXYC/wxyc-etl to use for the script"
+        type: string
+        default: "main"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout calling repo
+        uses: actions/checkout@v4
+        with:
+          path: target-repo
+
+      - name: Checkout wxyc-etl (for the script)
+        uses: actions/checkout@v4
+        with:
+          repository: WXYC/wxyc-etl
+          ref: ${{ inputs.wxyc-etl-ref }}
+          path: wxyc-etl
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install script dependencies
+        run: pip install pyyaml
+
+      - name: Check marker / CI sync
+        run: |
+          python "$GITHUB_WORKSPACE/wxyc-etl/scripts/check_marker_ci_sync.py" \
+            --repo-path "$GITHUB_WORKSPACE/target-repo/${{ inputs.repo-path }}" \
+            --workflows-dir "$GITHUB_WORKSPACE/target-repo/${{ inputs.workflows-dir }}" \
+            --tests-dir "$GITHUB_WORKSPACE/target-repo/${{ inputs.tests-dir }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,20 @@ jobs:
         run: pytest wxyc-etl-python/tests/ -v
       - name: Run wheel lifecycle test
         run: python tests/test_wheel_lifecycle.py --skip-build
+
+  marker-sync-self-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pyyaml pytest
+      - name: Unit-test the script
+        run: pytest scripts/test_check_marker_ci_sync.py -v
+      - name: Dogfood the script on this repo
+        run: |
+          python scripts/check_marker_ci_sync.py \
+            --repo-path wxyc-etl-python \
+            --workflows-dir .github/workflows \
+            --tests-dir wxyc-etl-python/tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/target
+/wxyc-etl-python/target
+**/__pycache__/
+**/.pytest_cache/
+*.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,23 @@ Four jobs on push to `main` and on PR:
 | `test-postgres` | `cargo test --workspace -- --test-threads=1` against a Postgres 16 service container on port 5433. |
 | `python-wheel` | maturin builds a release wheel, pip installs it, runs `pytest wxyc-etl-python/tests/`, then runs the wheel-lifecycle smoke test. |
 
+## Reusable: CI marker / workflow sync check
+
+`scripts/check_marker_ci_sync.py` verifies a repo's pytest marker scheme stays in sync with its CI invocations. It catches the WXYC/discogs-etl#103 failure mode (markers excluded by addopts, no CI job re-selects them, marked tests silently dropped). Sister WXYC repos invoke it via the reusable workflow `.github/workflows/check-ci-marker-sync.yml`:
+
+```yaml
+# in another repo's .github/workflows/ci.yml
+jobs:
+  marker-sync:
+    uses: WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main
+    with:
+      repo-path: "."           # or "subpkg/" if pyproject lives in a subdir
+      workflows-dir: ".github/workflows"
+      tests-dir: "tests"
+```
+
+Intentional opt-out for a marker that is, by design, manual-only: add `# ci-sync-skip: <marker> reason: <text>` anywhere in pyproject.toml (the script greps the raw text). See `wxyc-etl-python/pyproject.toml` for a live example (the `perf` marker).
+
 ## Consumers
 
 Repos that depend on wxyc-etl by Cargo path or via the Python wheel:

--- a/scripts/check_marker_ci_sync.py
+++ b/scripts/check_marker_ci_sync.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Verify pytest marker scheme stays in sync with CI workflows.
+
+The bug pattern this guards against (originally surfaced by WXYC/discogs-etl#103):
+a repo declares pytest markers (e.g. `postgres`, `integration`, `e2e`), addopts
+deselects them by default, and the CI workflow either has no job that
+re-selects them or invokes pytest without `-m` overriding addopts. Marked tests
+exist, contributors assume CI runs them, CI silently deselects them. The bug is
+invisible because pytest reports "N deselected" rather than "0 ran".
+
+This script reads ``pyproject.toml`` (markers + addopts) and every
+``.github/workflows/*.yml`` (every step that invokes pytest), and fails when a
+marker actually used by a test in this repo is excluded by addopts AND not
+explicitly re-selected by any CI invocation.
+
+Opt-out: place a comment anywhere in pyproject.toml of the form
+``# ci-sync-skip: <marker> reason: <text>`` and the script will skip that
+marker (e.g. for markers that are intentionally manual-only).
+
+Exit codes:
+  0 — all used markers are reachable from CI (or opted out)
+  1 — at least one used marker is silently deselected by CI
+  2 — script could not run (missing files, parse error)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from collections.abc import Iterable
+from pathlib import Path
+
+import yaml
+
+# Markers built into pytest or common plugins; never flag these as gaps.
+BUILTIN_MARKERS = frozenset({
+    "asyncio",
+    "filterwarnings",
+    "parametrize",
+    "skip",
+    "skipif",
+    "usefixtures",
+    "xfail",
+})
+
+
+def find_used_markers(tests_dir: Path) -> set[str]:
+    """Return every marker referenced via ``@pytest.mark.X`` or ``pytest.mark.X``."""
+    if not tests_dir.exists():
+        return set()
+    pattern = re.compile(r"pytest\.mark\.(\w+)")
+    markers: set[str] = set()
+    for py_file in tests_dir.rglob("*.py"):
+        try:
+            text = py_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        markers.update(pattern.findall(text))
+    return markers - BUILTIN_MARKERS
+
+
+def parse_pyproject(repo: Path) -> tuple[set[str], set[str], dict[str, str]]:
+    """Return (declared_markers, addopts_excluded_markers, opt_outs)."""
+    pyproject = repo / "pyproject.toml"
+    if not pyproject.exists():
+        return set(), set(), {}
+    with pyproject.open("rb") as f:
+        data = tomllib.load(f)
+    pytest_cfg = data.get("tool", {}).get("pytest", {}).get("ini_options", {})
+
+    declared: set[str] = set()
+    for entry in pytest_cfg.get("markers", []):
+        # Each entry is "name: description"; take everything before the colon.
+        name = entry.split(":", 1)[0].strip()
+        if name:
+            declared.add(name)
+
+    addopts = pytest_cfg.get("addopts", "")
+    if isinstance(addopts, list):
+        addopts = " ".join(addopts)
+    excluded = set(re.findall(r"\bnot\s+(\w+)", addopts))
+
+    opt_outs: dict[str, str] = {}
+    raw = pyproject.read_text(encoding="utf-8")
+    for m in re.finditer(r"#\s*ci-sync-skip:\s*(\w+)(?:\s+reason:\s*([^\n]+))?", raw):
+        opt_outs[m.group(1)] = (m.group(2) or "").strip()
+
+    return declared, excluded, opt_outs
+
+
+def _parse_marker_expression(expr: str) -> set[str]:
+    """Extract positive marker terms from a pytest -m expression.
+
+    ``"postgres"`` -> {"postgres"}; ``"not slow"`` -> set();
+    ``"integration or postgres"`` -> {"integration", "postgres"};
+    ``"postgres and not slow"`` -> {"postgres"}.
+    """
+    tokens = re.findall(r"\(|\)|\bnot\b|\band\b|\bor\b|\b\w+\b", expr)
+    positives: set[str] = set()
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok == "not":
+            i += 2  # skip the marker that follows
+            continue
+        if tok in {"and", "or", "(", ")"}:
+            i += 1
+            continue
+        positives.add(tok)
+        i += 1
+    return positives
+
+
+def _iter_workflow_steps(workflows_dir: Path) -> Iterable[tuple[Path, str, str]]:
+    """Yield (workflow_path, job_name, run_script) for each step that runs pytest."""
+    if not workflows_dir.exists():
+        return
+    for wf in sorted(workflows_dir.glob("*.yml")):
+        try:
+            data = yaml.safe_load(wf.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        for job_name, job in (data.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            for step in job.get("steps") or []:
+                if not isinstance(step, dict):
+                    continue
+                run = step.get("run", "")
+                if isinstance(run, str) and "pytest" in run:
+                    yield wf, job_name, run
+
+
+def find_ci_selected_markers(workflows_dir: Path) -> tuple[set[str], bool]:
+    """Return (markers_explicitly_selected_by_some_pytest_job, any_pytest_runs_without_m).
+
+    A marker is "selected" if some CI pytest invocation passes ``-m "..."`` whose
+    expression includes the marker as a positive term. ``any_pytest_runs_without_m``
+    is True when at least one pytest step omits ``-m`` entirely (so it inherits
+    addopts and would deselect addopts-excluded markers).
+    """
+    selected: set[str] = set()
+    any_without_m = False
+    m_arg_re = re.compile(r"-m[ =]+(?:\"([^\"]+)\"|'([^']+)')")
+    for _, _, run in _iter_workflow_steps(workflows_dir):
+        # Only count -m args attached to a pytest invocation. A single run
+        # script may invoke pytest multiple times; analyse each line.
+        for line in run.splitlines():
+            if "pytest" not in line:
+                continue
+            args = list(m_arg_re.finditer(line))
+            if not args:
+                any_without_m = True
+                continue
+            for a in args:
+                expr = a.group(1) or a.group(2) or ""
+                selected.update(_parse_marker_expression(expr))
+    return selected, any_without_m
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-path",
+        type=Path,
+        default=Path.cwd(),
+        help="Repo root (default: cwd)",
+    )
+    parser.add_argument(
+        "--tests-dir",
+        type=Path,
+        default=None,
+        help="Override tests dir (default: <repo>/tests)",
+    )
+    parser.add_argument(
+        "--workflows-dir",
+        type=Path,
+        default=None,
+        help="Override CI workflows dir (default: <repo>/.github/workflows)",
+    )
+    args = parser.parse_args(argv)
+
+    repo = args.repo_path.resolve()
+    workflows_dir = (
+        args.workflows_dir.resolve() if args.workflows_dir else repo / ".github" / "workflows"
+    )
+    tests_dir = args.tests_dir.resolve() if args.tests_dir else repo / "tests"
+
+    if not workflows_dir.exists():
+        print(f"FAIL: no .github/workflows directory at {workflows_dir}", file=sys.stderr)
+        return 2
+
+    used = find_used_markers(tests_dir)
+    declared, excluded, opt_outs = parse_pyproject(repo)
+    selected, any_without_m = find_ci_selected_markers(workflows_dir)
+
+    print(f"Repo:                      {repo}")
+    print(f"Tests dir:                 {tests_dir}")
+    print(f"Markers used by tests:     {sorted(used) or '(none)'}")
+    print(f"Markers declared in toml:  {sorted(declared) or '(none)'}")
+    print(f"Excluded by addopts:       {sorted(excluded) or '(none)'}")
+    print(f"Selected by CI -m args:    {sorted(selected) or '(none)'}")
+    print(f"Some CI step runs pytest without -m: {any_without_m}")
+    if opt_outs:
+        print(f"Opt-outs (ci-sync-skip):   {opt_outs}")
+    print()
+
+    gaps: list[str] = []
+    for marker in sorted(used):
+        if marker in opt_outs:
+            print(f"  SKIP {marker}: opt-out -- {opt_outs[marker] or '(no reason given)'}")
+            continue
+        deselected_by_default = marker in excluded
+        reachable = (not deselected_by_default) or (marker in selected)
+        if reachable:
+            print(f"  OK   {marker}")
+        else:
+            gaps.append(marker)
+            print(f"  GAP  {marker}: excluded by addopts, no CI -m argument re-selects it")
+
+    orphans = sorted(declared - used)
+    if orphans:
+        print()
+        print(f"Note (warning, not gap): markers declared but never used by any test: {orphans}")
+
+    print()
+    if gaps:
+        print(f"FAIL: {len(gaps)} marker(s) silently deselected by CI: {gaps}", file=sys.stderr)
+        print(
+            "Fix: either add a CI job that runs `pytest -m \"<marker>\" ...`, "
+            "remove the marker from addopts, or document an intentional opt-out "
+            "with a `# ci-sync-skip: <marker> reason: <text>` comment in pyproject.toml.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("PASS: every used marker is reachable from CI")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_marker_ci_sync.py
+++ b/scripts/test_check_marker_ci_sync.py
@@ -1,0 +1,269 @@
+"""Unit tests for ``check_marker_ci_sync``."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from check_marker_ci_sync import (
+    _parse_marker_expression,
+    find_ci_selected_markers,
+    find_used_markers,
+    main,
+    parse_pyproject,
+)
+
+
+@pytest.mark.parametrize(
+    "expr,expected",
+    [
+        ("postgres", {"postgres"}),
+        ("not slow", set()),
+        ("integration or postgres", {"integration", "postgres"}),
+        ("postgres and not slow", {"postgres"}),
+        ("not slow and not integration", set()),
+        ("(postgres or e2e) and not slow", {"postgres", "e2e"}),
+        ("", set()),
+    ],
+)
+def test_parse_marker_expression(expr: str, expected: set[str]) -> None:
+    assert _parse_marker_expression(expr) == expected
+
+
+def _make_repo(tmp_path: Path, *, pyproject: str, workflow: str, tests: dict[str, str]) -> Path:
+    (tmp_path / "pyproject.toml").write_text(textwrap.dedent(pyproject))
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "ci.yml").write_text(textwrap.dedent(workflow))
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    for name, body in tests.items():
+        (tests_dir / name).write_text(textwrap.dedent(body))
+    return tmp_path
+
+
+def test_pass_when_marker_excluded_but_re_selected_by_ci(tmp_path: Path) -> None:
+    repo = _make_repo(
+        tmp_path,
+        pyproject="""
+            [tool.pytest.ini_options]
+            markers = ["postgres: pg-backed tests"]
+            addopts = "-m 'not postgres'"
+        """,
+        workflow="""
+            jobs:
+              test-postgres:
+                steps:
+                  - run: pytest -m "postgres" tests/
+        """,
+        tests={"test_x.py": "import pytest\n@pytest.mark.postgres\ndef test_a(): pass\n"},
+    )
+    assert main(["--repo-path", str(repo)]) == 0
+
+
+def test_fail_when_marker_excluded_and_no_ci_re_selects(tmp_path: Path) -> None:
+    repo = _make_repo(
+        tmp_path,
+        pyproject="""
+            [tool.pytest.ini_options]
+            markers = ["postgres: pg tests"]
+            addopts = "-m 'not postgres'"
+        """,
+        workflow="""
+            jobs:
+              test:
+                steps:
+                  - run: pytest -v tests/
+        """,
+        tests={"test_x.py": "import pytest\n@pytest.mark.postgres\ndef test_a(): pass\n"},
+    )
+    assert main(["--repo-path", str(repo)]) == 1
+
+
+def test_pass_when_addopts_does_not_exclude_marker(tmp_path: Path) -> None:
+    repo = _make_repo(
+        tmp_path,
+        pyproject="""
+            [tool.pytest.ini_options]
+            markers = ["unit: fast unit tests"]
+        """,
+        workflow="""
+            jobs:
+              test:
+                steps:
+                  - run: pytest -v tests/
+        """,
+        tests={"test_x.py": "import pytest\n@pytest.mark.unit\ndef test_a(): pass\n"},
+    )
+    assert main(["--repo-path", str(repo)]) == 0
+
+
+def test_opt_out_skips_gap(tmp_path: Path) -> None:
+    repo = _make_repo(
+        tmp_path,
+        pyproject="""
+            # ci-sync-skip: e2e reason: manual run only
+            [tool.pytest.ini_options]
+            markers = ["e2e: end-to-end (manual)"]
+            addopts = "-m 'not e2e'"
+        """,
+        workflow="""
+            jobs:
+              test:
+                steps:
+                  - run: pytest -v tests/
+        """,
+        tests={"test_x.py": "import pytest\n@pytest.mark.e2e\ndef test_a(): pass\n"},
+    )
+    assert main(["--repo-path", str(repo)]) == 0
+
+
+def test_orphan_markers_are_not_a_gap(tmp_path: Path) -> None:
+    """A marker declared in pyproject but never used by any test is a soft warning, not a failure."""
+    repo = _make_repo(
+        tmp_path,
+        pyproject="""
+            [tool.pytest.ini_options]
+            markers = [
+                "unit: fast unit tests",
+                "parity: declared but unused",
+            ]
+            addopts = "-m 'not parity'"
+        """,
+        workflow="""
+            jobs:
+              test:
+                steps:
+                  - run: pytest -v tests/
+        """,
+        tests={"test_x.py": "import pytest\n@pytest.mark.unit\ndef test_a(): pass\n"},
+    )
+    assert main(["--repo-path", str(repo)]) == 0
+
+
+def test_compound_addopts_excludes_multiple_markers(tmp_path: Path) -> None:
+    repo = _make_repo(
+        tmp_path,
+        pyproject="""
+            [tool.pytest.ini_options]
+            markers = ["integration: int", "postgres: pg", "e2e: end"]
+            addopts = "-m 'not integration and not postgres and not e2e'"
+        """,
+        workflow="""
+            jobs:
+              integration:
+                steps:
+                  - run: pytest -m "integration" tests/
+              postgres:
+                steps:
+                  - run: pytest -m "postgres" tests/
+        """,
+        tests={
+            "test_x.py": (
+                "import pytest\n"
+                "@pytest.mark.integration\n"
+                "def test_a(): pass\n"
+                "@pytest.mark.postgres\n"
+                "def test_b(): pass\n"
+                "@pytest.mark.e2e\n"
+                "def test_c(): pass\n"
+            ),
+        },
+    )
+    # e2e should be flagged: declared+used+excluded but no CI job selects it.
+    assert main(["--repo-path", str(repo)]) == 1
+
+
+def test_pytestmark_module_marker_detected(tmp_path: Path) -> None:
+    """The module-level ``pytestmark = pytest.mark.X`` form must be detected."""
+    repo = _make_repo(
+        tmp_path,
+        pyproject="""
+            [tool.pytest.ini_options]
+            markers = ["postgres: pg"]
+            addopts = "-m 'not postgres'"
+        """,
+        workflow="""
+            jobs:
+              test:
+                steps:
+                  - run: pytest -v tests/
+        """,
+        tests={"test_x.py": "import pytest\npytestmark = pytest.mark.postgres\ndef test_a(): pass\n"},
+    )
+    assert main(["--repo-path", str(repo)]) == 1  # postgres used via pytestmark, no CI selects
+
+
+def test_addopts_as_list(tmp_path: Path) -> None:
+    """addopts may be a list of args; the script should handle that form."""
+    pyproject = """
+        [tool.pytest.ini_options]
+        markers = ["postgres: pg"]
+        addopts = ["-v", "-m", "not postgres"]
+    """
+    (tmp_path / "pyproject.toml").write_text(textwrap.dedent(pyproject))
+    declared, excluded, _ = parse_pyproject(tmp_path)
+    assert excluded == {"postgres"}
+
+
+def test_no_workflows_dir_returns_2(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[tool.pytest.ini_options]\nmarkers=[]\n")
+    assert main(["--repo-path", str(tmp_path)]) == 2
+
+
+def test_ci_with_pytest_in_compound_command(tmp_path: Path) -> None:
+    """``pytest`` invoked alongside other commands in one run: block."""
+    repo = _make_repo(
+        tmp_path,
+        pyproject="""
+            [tool.pytest.ini_options]
+            markers = ["postgres: pg"]
+            addopts = "-m 'not postgres'"
+        """,
+        workflow="""
+            jobs:
+              test:
+                steps:
+                  - run: |
+                      pip install -e .
+                      pytest -m "postgres" tests/
+        """,
+        tests={"test_x.py": "import pytest\n@pytest.mark.postgres\ndef test_a(): pass\n"},
+    )
+    assert main(["--repo-path", str(repo)]) == 0
+
+
+def test_finds_ci_selected_markers_handles_quotes(tmp_path: Path) -> None:
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "ci.yml").write_text(textwrap.dedent("""
+        jobs:
+          a:
+            steps:
+              - run: pytest -m "postgres or integration" tests/
+          b:
+            steps:
+              - run: pytest -m 'e2e' tests/
+          c:
+            steps:
+              - run: pytest -v tests/
+    """))
+    selected, any_without_m = find_ci_selected_markers(wf_dir)
+    assert selected == {"postgres", "integration", "e2e"}
+    assert any_without_m is True
+
+
+def test_find_used_markers_filters_builtins(tmp_path: Path) -> None:
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_x.py").write_text(
+        "import pytest\n"
+        "@pytest.mark.parametrize('x', [1])\n"
+        "@pytest.mark.skip\n"
+        "@pytest.mark.postgres\n"
+        "def test_a(x): pass\n"
+    )
+    used = find_used_markers(tests_dir)
+    assert used == {"postgres"}

--- a/wxyc-etl-python/pyproject.toml
+++ b/wxyc-etl-python/pyproject.toml
@@ -13,15 +13,10 @@ dev = ["pytest>=7.0"]
 [tool.maturin]
 features = ["pyo3/extension-module"]
 
+# ci-sync-skip: perf reason: benchmarks require a release-built wheel and are run manually
 [tool.pytest.ini_options]
 markers = [
-    "unit: pure logic tests, no external dependencies",
-    "postgres: needs PostgreSQL (gated by DATABASE_URL_TEST)",
-    "integration: needs external service or fixture data",
-    "e2e: full pipeline end-to-end test",
-    "parity: old vs new implementation comparison",
-    "slow: marks tests as slow",
-    "perf: performance benchmarks (require release build)",
+    "perf: performance benchmarks (require release build, manual run only)",
 ]
-addopts = "-m 'not integration and not postgres and not e2e and not parity and not slow and not perf'"
+addopts = "-m 'not perf'"
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Adds `scripts/check_marker_ci_sync.py` plus a reusable workflow `.github/workflows/check-ci-marker-sync.yml`. Sister WXYC repos can wire in the check with one job declaration:

```yaml
jobs:
  marker-sync:
    uses: WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main
    with:
      repo-path: "."
```

## Why

Guards against the WXYC/discogs-etl#103 failure mode: a repo declares pytest markers, addopts excludes them by default, and CI either omits the re-selecting `-m` argument or has no job for the marker. Marked tests appear as "deselected" rather than failing — the gap is invisible. Five sister repos surfaced this exact pattern in WXYC/wiki#1 (LML #159, semantic-index #186, musicbrainz-cache #21, wxyc-catalog #18, wxyc-etl #42).

## Closes

- Closes WXYC/wxyc-etl#42 — the audit's "no CI workflow" finding was stale (CI exists since `690e347`); this PR also closes the loop by making the sync gate self-host on this repo's `marker-sync-self-check` job.

## Notes

- Dogfood caught a real gap on `wxyc-etl-python/pyproject.toml`: it declared the standard six-marker scheme on `main` but only `perf` is used, and CI was silently dropping `perf`. Cleaned up to declare only the actually-used marker and marked it as intentional manual-only opt-out (release wheel required).
- 19 unit tests on the script (parametrized expression parsing, list-form addopts, monorepo paths, opt-outs, orphan markers).
- After this merges, follow-up PRs in LML / SI / MBC / WC will: (a) close their gap (add the missing CI job), (b) wire in this reusable workflow as a guardrail.

## Test plan

- [x] 19 unit tests pass locally
- [x] Self-dogfood on wxyc-etl-python passes
- [ ] CI green on this PR (lint + test + test-postgres + python-wheel + marker-sync-self-check)