### PR TITLE
Add logger module for Sentry + structured JSON logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 **/__pycache__/
 **/.pytest_cache/
 *.pyc
+*.so
+.venv/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,14 +27,75 @@ The Python crate lives in the same workspace so it shares the lockfile with the 
 | `schema` | Table-name constants for the consumer databases (`schema::library`, `schema::discogs`, `schema::musicbrainz`, `schema::wikidata`, `schema::entity`). Single source of truth so consumer Rust code never hard-codes table names. |
 | `fuzzy` | `LibraryIndex` (token-set + Jaro-Winkler scoring), batch filter via normalize + set lookup, classification metrics. |
 | `parser` | Streaming MySQL `INSERT INTO ... VALUES (...)` tuple parser used to read tubafrenzy SQL dumps without loading them into memory. |
+| `logger` | Sentry + structured JSON logging (`tracing` + `tracing-subscriber` JSON). See **Observability** below. |
+
+## Observability
+
+Every ETL binary should call `wxyc_etl::logger::init` (Rust) or `wxyc_etl.logger.init_logger` (Python) once at startup. Both emit one JSON object per line on stderr with four required tags so logs are uniformly aggregatable across pipelines:
+
+| Tag | Source | Example |
+|---|---|---|
+| `repo` | passed to `init` | `"musicbrainz-cache"` |
+| `tool` | passed to `init` | `"musicbrainz-cache build"` |
+| `step` | per-event field | `"import"`, `"resolve"`, `"copy"` |
+| `run_id` | UUIDv4 (or override) | `"4eb6f1b7-..."` |
+
+When the `SENTRY_DSN` env var is set (or `sentry_dsn` is passed in), panics and `tracing::error!` events (Rust) / `logger.error` events (Python) are forwarded to Sentry tagged with the same fields.
+
+### Rust
+
+```rust
+use wxyc_etl::logger::{self, LoggerConfig};
+
+fn main() {
+    let _guard = logger::init(LoggerConfig {
+        repo: "musicbrainz-cache",
+        tool: "musicbrainz-cache build",
+        sentry_dsn: None,         // falls back to SENTRY_DSN env
+        run_id: None,             // generates UUIDv4
+    });
+
+    tracing::info_span!("import", step = "import").in_scope(|| {
+        tracing::info!(rows = 42, "loaded recordings");
+    });
+}
+```
+
+The guard must be held for the lifetime of `main` so Sentry flushes on drop.
+
+### Python
+
+```python
+from wxyc_etl.logger import init_logger
+import logging
+
+guard = init_logger(repo="discogs-etl", tool="discogs-etl daily-sync")
+
+log = logging.getLogger(__name__)
+log.info("loaded recordings", extra={"step": "import", "rows": 42})
+```
+
+`init_logger` is idempotent — calling it again replaces the tag values without re-installing handlers. Drop the guard or call `guard.flush()` to drain Sentry before exit (also registered via `atexit`).
 
 `lib.rs` re-exports each module unchanged: consumers do `use wxyc_etl::text::normalize_artist_name`.
 
 ## Python Bindings (`wxyc-etl-python/`)
 
-The PyO3 crate registers each submodule under the `wxyc_etl` Python package so `from wxyc_etl.text import normalize_artist_name` works. Currently exposed: `text`, `parser`, `state`, `import_utils`, `schema`, `fuzzy`. The `pg`, `pipeline`, `csv_writer`, and `sqlite` modules are not exposed — Python consumers don't need them (they have psycopg/asyncpg directly).
+Mixed Rust/Python package laid out as:
 
-Submodule registration also writes into `sys.modules` so Python's `from X.Y import Z` form resolves correctly (PyO3 doesn't do this by default).
+```
+wxyc-etl-python/
+  src/                  # Rust extension, built as wxyc_etl._native
+  python/wxyc_etl/      # pure-Python helpers
+    __init__.py         # re-exports the Rust submodules
+    logger.py           # Sentry + JSON logging (pure Python)
+```
+
+`pyproject.toml` has `python-source = "python"` and `module-name = "wxyc_etl._native"` so maturin packs both halves into a single `wxyc_etl` package. The Rust crate registers its submodules under `wxyc_etl.<name>` in `sys.modules` so consumers can use either `from wxyc_etl.text import ...` or `from wxyc_etl import text`. Pure-Python additions go in `python/wxyc_etl/*.py`.
+
+Currently exposed Rust submodules: `text`, `parser`, `state`, `import_utils`, `schema`, `fuzzy`. The `pg`, `pipeline`, `csv_writer`, and `sqlite` modules are not exposed — Python consumers don't need them (they have psycopg/asyncpg directly).
+
+Pure-Python helpers: `logger`.
 
 ### Install for downstream Python repos
 

--- a/wxyc-etl-python/Cargo.toml
+++ b/wxyc-etl-python/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [lib]
-name = "wxyc_etl"
+name = "_native"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/wxyc-etl-python/pyproject.toml
+++ b/wxyc-etl-python/pyproject.toml
@@ -6,12 +6,18 @@ build-backend = "maturin"
 name = "wxyc-etl"
 requires-python = ">=3.9"
 dynamic = ["version"]
+dependencies = [
+    "sentry-sdk>=2.0",
+    "python-json-logger>=2.0",
+]
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0"]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
+python-source = "python"
+module-name = "wxyc_etl._native"
 
 # ci-sync-skip: perf reason: benchmarks require a release-built wheel and are run manually
 [tool.pytest.ini_options]

--- a/wxyc-etl-python/python/wxyc_etl/__init__.py
+++ b/wxyc-etl-python/python/wxyc_etl/__init__.py
@@ -1,0 +1,30 @@
+"""Python bindings for the wxyc-etl Rust crate, plus pure-Python helpers.
+
+The Rust extension lives at :mod:`wxyc_etl._native`; its submodules
+(``text``, ``parser``, ``state``, ``import_utils``, ``schema``, ``fuzzy``) are
+re-exported here so callers can use the historical ``from wxyc_etl import
+text`` and ``from wxyc_etl.text import normalize_artist_name`` forms
+interchangeably.
+
+The :mod:`wxyc_etl.logger` module is pure Python; see its docstring for usage.
+"""
+
+from . import _native
+from ._native import (
+    fuzzy,
+    import_utils,
+    parser,
+    schema,
+    state,
+    text,
+)
+
+__all__ = [
+    "fuzzy",
+    "import_utils",
+    "logger",
+    "parser",
+    "schema",
+    "state",
+    "text",
+]

--- a/wxyc-etl-python/python/wxyc_etl/logger.py
+++ b/wxyc-etl-python/python/wxyc_etl/logger.py
@@ -1,0 +1,173 @@
+"""Sentry + structured JSON logging for WXYC ETL pipelines (Python side).
+
+Mirrors :mod:`wxyc_etl::logger` (Rust). Every Python ETL should call
+:func:`init_logger` once at startup with a ``repo`` and ``tool`` identifying
+the pipeline. Logs emit one JSON object per line on the root logger with the
+tags ``repo``, ``tool``, ``step``, and ``run_id`` (``step`` is set per-call via
+:func:`logging.Logger.info` ``extra=`` or via :class:`LoggerStep`). When
+``SENTRY_DSN`` is set in the environment (or supplied to :func:`init_logger`)
+unhandled exceptions and ``logger.error`` events are forwarded to Sentry with
+the same tags.
+
+Usage::
+
+    from wxyc_etl.logger import init_logger
+
+    guard = init_logger(repo="discogs-etl", tool="discogs-etl daily-sync")
+
+    import logging
+    log = logging.getLogger(__name__)
+    log.info("loaded recordings", extra={"step": "import", "rows": 42})
+
+The returned :class:`LoggerGuard` flushes pending Sentry events when its
+``flush`` method is called (or when the program exits).
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import sys
+import uuid
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class LoggerConfig:
+    """Configuration for :func:`init_logger`. ``sentry_dsn=None`` falls back to
+    the ``SENTRY_DSN`` env var; ``run_id=None`` generates a UUIDv4."""
+
+    repo: str
+    tool: str
+    sentry_dsn: Optional[str] = None
+    run_id: Optional[str] = None
+
+
+class LoggerGuard:
+    """Returned by :func:`init_logger`. Call :meth:`flush` (or rely on the
+    ``atexit`` hook) to drain Sentry before the process exits.
+    """
+
+    def __init__(self, run_id: str, sentry_enabled: bool) -> None:
+        self.run_id = run_id
+        self.sentry_enabled = sentry_enabled
+
+    def flush(self, timeout: float = 2.0) -> None:
+        if not self.sentry_enabled:
+            return
+        try:
+            import sentry_sdk
+
+            client = sentry_sdk.Hub.current.client
+            if client is not None:
+                client.flush(timeout=timeout)
+        except Exception:  # pragma: no cover - flush is best-effort
+            pass
+
+
+class _ContextFilter(logging.Filter):
+    """Inject repo/tool/run_id onto every record so the JSON formatter emits
+    them. Per-event ``step`` is supplied by callers via ``extra={"step": ...}``
+    and survives this filter unchanged.
+    """
+
+    def __init__(self, repo: str, tool: str, run_id: str) -> None:
+        super().__init__()
+        self._repo = repo
+        self._tool = tool
+        self._run_id = run_id
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if not hasattr(record, "repo"):
+            record.repo = self._repo
+        if not hasattr(record, "tool"):
+            record.tool = self._tool
+        if not hasattr(record, "run_id"):
+            record.run_id = self._run_id
+        if not hasattr(record, "step"):
+            record.step = ""
+        return True
+
+
+_INITIALIZED = False
+
+
+def init_logger(
+    repo: str,
+    tool: str,
+    sentry_dsn: Optional[str] = None,
+    run_id: Optional[str] = None,
+    level: int = logging.INFO,
+) -> LoggerGuard:
+    """Initialize Sentry (when DSN is available) and JSON logging on the root
+    logger. Idempotent: subsequent calls update tags but don't double-install
+    handlers.
+    """
+
+    global _INITIALIZED
+
+    rid = run_id or str(uuid.uuid4())
+    dsn = sentry_dsn if sentry_dsn is not None else os.environ.get("SENTRY_DSN")
+    sentry_enabled = bool(dsn)
+
+    if sentry_enabled:
+        import sentry_sdk
+
+        sentry_sdk.init(
+            dsn=dsn,
+            traces_sample_rate=0.0,
+            attach_stacktrace=True,
+        )
+        sentry_sdk.set_tag("repo", repo)
+        sentry_sdk.set_tag("tool", tool)
+        sentry_sdk.set_tag("run_id", rid)
+
+    if not _INITIALIZED:
+        try:
+            from pythonjsonlogger.json import JsonFormatter
+        except ImportError:
+            try:
+                from pythonjsonlogger.jsonlogger import (  # type: ignore[no-redef]
+                    JsonFormatter,
+                )
+            except ImportError as exc:  # pragma: no cover - dep is declared
+                raise RuntimeError(
+                    "wxyc_etl.logger requires python-json-logger; "
+                    "ensure the wxyc-etl wheel's runtime deps are installed"
+                ) from exc
+
+        formatter = JsonFormatter(
+            "%(asctime)s %(levelname)s %(name)s %(message)s "
+            "%(repo)s %(tool)s %(step)s %(run_id)s",
+            rename_fields={"asctime": "timestamp", "levelname": "level"},
+        )
+
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(formatter)
+        handler.addFilter(_ContextFilter(repo, tool, rid))
+
+        root = logging.getLogger()
+        root.addHandler(handler)
+        root.setLevel(level)
+
+        guard = LoggerGuard(rid, sentry_enabled)
+        atexit.register(guard.flush)
+        _INITIALIZED = True
+        return guard
+
+    # Already initialized: reset the context filter on existing handlers so
+    # the new repo/tool/run_id apply going forward.
+    new_filter = _ContextFilter(repo, tool, rid)
+    for handler in logging.getLogger().handlers:
+        # Drop any prior _ContextFilter to avoid duplicate-tag injection.
+        for existing in list(handler.filters):
+            if isinstance(existing, _ContextFilter):
+                handler.removeFilter(existing)
+        handler.addFilter(new_filter)
+
+    return LoggerGuard(rid, sentry_enabled)
+
+
+__all__ = ["LoggerConfig", "LoggerGuard", "init_logger"]

--- a/wxyc-etl-python/src/lib.rs
+++ b/wxyc-etl-python/src/lib.rs
@@ -29,7 +29,7 @@ fn register_submodule(
 }
 
 #[pymodule]
-fn wxyc_etl(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn _native(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     register_submodule(py, m, "text", text::register)?;
     register_submodule(py, m, "parser", parser::register)?;
     register_submodule(py, m, "state", state::register)?;

--- a/wxyc-etl-python/tests/test_logger.py
+++ b/wxyc-etl-python/tests/test_logger.py
@@ -1,0 +1,98 @@
+"""Tests for the wxyc_etl.logger Python helper."""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+
+import pytest
+
+from wxyc_etl.logger import LoggerGuard, init_logger
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging(monkeypatch):
+    """Reset the global root logger and the module's init flag between tests so
+    each test sees a clean handler chain."""
+
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    root.handlers.clear()
+
+    import wxyc_etl.logger as mod
+
+    monkeypatch.setattr(mod, "_INITIALIZED", False)
+
+    yield
+
+    root.handlers = saved_handlers
+    root.setLevel(saved_level)
+
+
+def _capture_handler_output(monkeypatch) -> io.StringIO:
+    buf = io.StringIO()
+    monkeypatch.setattr("sys.stderr", buf)
+    return buf
+
+
+def test_init_without_dsn_returns_guard(monkeypatch):
+    buf = _capture_handler_output(monkeypatch)
+
+    guard = init_logger(repo="test-repo", tool="test-tool")
+
+    assert isinstance(guard, LoggerGuard)
+    assert guard.run_id  # generated UUID
+    assert guard.sentry_enabled is False
+
+    logging.getLogger("wxyc.test").info("hello", extra={"step": "load"})
+
+    line = buf.getvalue().strip().splitlines()[0]
+    payload = json.loads(line)
+    assert payload["repo"] == "test-repo"
+    assert payload["tool"] == "test-tool"
+    assert payload["step"] == "load"
+    assert payload["run_id"] == guard.run_id
+    assert payload["message"] == "hello"
+    assert payload["level"] == "INFO"
+
+
+def test_init_uses_provided_run_id(monkeypatch):
+    _capture_handler_output(monkeypatch)
+    guard = init_logger(repo="r", tool="t", run_id="fixed-run-1234")
+    assert guard.run_id == "fixed-run-1234"
+
+
+def test_init_idempotent_updates_tags(monkeypatch):
+    buf = _capture_handler_output(monkeypatch)
+
+    init_logger(repo="first", tool="first-tool", run_id="run-1")
+    init_logger(repo="second", tool="second-tool", run_id="run-2")
+
+    logging.getLogger("wxyc.test").info("after-second")
+    line = buf.getvalue().strip().splitlines()[-1]
+    payload = json.loads(line)
+    assert payload["repo"] == "second"
+    assert payload["tool"] == "second-tool"
+    assert payload["run_id"] == "run-2"
+
+
+def test_step_defaults_to_empty_when_missing(monkeypatch):
+    buf = _capture_handler_output(monkeypatch)
+
+    init_logger(repo="r", tool="t", run_id="run-x")
+    logging.getLogger("wxyc.test").info("no-step")
+
+    payload = json.loads(buf.getvalue().strip().splitlines()[0])
+    assert payload["step"] == ""
+
+
+def test_init_with_empty_dsn_does_not_enable_sentry(monkeypatch):
+    monkeypatch.setenv("SENTRY_DSN", "")
+    _capture_handler_output(monkeypatch)
+    guard = init_logger(repo="r", tool="t")
+    assert guard.sentry_enabled is False

--- a/wxyc-etl/Cargo.toml
+++ b/wxyc-etl/Cargo.toml
@@ -40,5 +40,14 @@ anyhow = "1"
 log = "0.4"
 env_logger = "0.11"
 
+# logger module
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter", "registry"] }
+tracing-log = "0.2"
+sentry = { version = "0.34", default-features = false, features = ["backtrace", "contexts", "panic", "rustls", "reqwest"] }
+sentry-tracing = "0.34"
+uuid = { version = "1", features = ["v4"] }
+
 [dev-dependencies]
 tempfile = "3"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter", "registry"] }

--- a/wxyc-etl/src/lib.rs
+++ b/wxyc-etl/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod csv_writer;
 pub mod fuzzy;
 pub mod import;
+pub mod logger;
 pub mod parser;
 pub mod pg;
 pub mod pipeline;

--- a/wxyc-etl/src/logger.rs
+++ b/wxyc-etl/src/logger.rs
@@ -1,0 +1,170 @@
+//! Sentry + structured JSON logging for WXYC ETL pipelines.
+//!
+//! Every ETL binary should call [`init`] once at startup with a [`LoggerConfig`]
+//! identifying the repo and tool. Logs emit as one JSON object per line with the
+//! tags `repo`, `tool`, `step`, and `run_id` (the last set per-span via
+//! `tracing` instrumentation). When `SENTRY_DSN` is set in the environment (or
+//! provided in the config) panics and `tracing::error!` events are forwarded to
+//! Sentry with the same tags.
+//!
+//! ## Usage
+//!
+//! ```no_run
+//! use wxyc_etl::logger::{self, LoggerConfig};
+//!
+//! fn main() {
+//!     let _guard = logger::init(LoggerConfig {
+//!         repo: "musicbrainz-cache",
+//!         tool: "musicbrainz-cache build",
+//!         sentry_dsn: None,
+//!         run_id: None,
+//!     });
+//!
+//!     tracing::info_span!("import", step = "import").in_scope(|| {
+//!         tracing::info!(rows = 42, "loaded recordings");
+//!     });
+//! }
+//! ```
+
+use std::sync::OnceLock;
+
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+/// Configuration for [`init`]. Pass `None` for `sentry_dsn` to fall back to the
+/// `SENTRY_DSN` environment variable; pass `None` for `run_id` to generate a
+/// fresh UUIDv4 for the run.
+pub struct LoggerConfig {
+    /// Repository name. Set as the Sentry tag `repo`.
+    pub repo: &'static str,
+    /// Tool name (typically `<repo> <subcommand>`). Set as the Sentry tag `tool`.
+    pub tool: &'static str,
+    /// Sentry DSN. `None` falls back to `SENTRY_DSN` env var; if neither is set
+    /// Sentry is disabled but JSON logging still initializes.
+    pub sentry_dsn: Option<String>,
+    /// Run identifier. `None` generates a UUIDv4. Set as the Sentry tag `run_id`.
+    pub run_id: Option<String>,
+}
+
+/// RAII guard returned by [`init`]. Drop it at the end of `main` to flush
+/// pending Sentry events before exit.
+pub struct LoggerGuard {
+    _sentry: Option<sentry::ClientInitGuard>,
+}
+
+static INIT: OnceLock<()> = OnceLock::new();
+
+/// Initialize Sentry and JSON logging. Safe to call once per process; later
+/// calls are a no-op (and return a `LoggerGuard` whose Sentry slot is empty).
+pub fn init(config: LoggerConfig) -> LoggerGuard {
+    let run_id = config
+        .run_id
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    let dsn = config
+        .sentry_dsn
+        .or_else(|| std::env::var("SENTRY_DSN").ok());
+
+    let mut sentry_guard = None;
+    if let Some(dsn) = dsn.as_deref().filter(|s| !s.is_empty()) {
+        let guard = sentry::init((
+            dsn.to_string(),
+            sentry::ClientOptions {
+                release: sentry::release_name!(),
+                attach_stacktrace: true,
+                ..Default::default()
+            },
+        ));
+        sentry::configure_scope(|scope| {
+            scope.set_tag("repo", config.repo);
+            scope.set_tag("tool", config.tool);
+            scope.set_tag("run_id", &run_id);
+        });
+        sentry_guard = Some(guard);
+    }
+
+    if INIT.set(()).is_ok() {
+        let _ = tracing_log::LogTracer::init();
+
+        let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+
+        let json_layer = tracing_subscriber::fmt::layer()
+            .json()
+            .with_current_span(true)
+            .with_span_list(false)
+            .with_target(true);
+
+        let registry = tracing_subscriber::registry()
+            .with(env_filter)
+            .with(json_layer);
+
+        if sentry_guard.is_some() {
+            let _ = registry.with(sentry_tracing::layer()).try_init();
+        } else {
+            let _ = registry.try_init();
+        }
+
+        // Re-set repo/tool/run_id as tracing fields on the root span so every
+        // event carries them even outside a user-defined span.
+        let span = tracing::info_span!(
+            "wxyc_etl",
+            repo = %config.repo,
+            tool = %config.tool,
+            run_id = %run_id,
+        );
+        let _ = span.entered();
+    }
+
+    LoggerGuard {
+        _sentry: sentry_guard,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_without_dsn_does_not_panic() {
+        // Safety net: explicitly clear SENTRY_DSN so the test is deterministic
+        // regardless of the surrounding env.
+        std::env::remove_var("SENTRY_DSN");
+        let _guard = init(LoggerConfig {
+            repo: "test-repo",
+            tool: "test-tool",
+            sentry_dsn: None,
+            run_id: Some("test-run".into()),
+        });
+    }
+
+    #[test]
+    fn init_generates_run_id_when_none() {
+        std::env::remove_var("SENTRY_DSN");
+        // Calling without a run_id should not panic; UUID generation is the
+        // only side effect we can observe externally without a custom writer.
+        let _guard = init(LoggerConfig {
+            repo: "test-repo",
+            tool: "test-tool",
+            sentry_dsn: None,
+            run_id: None,
+        });
+    }
+
+    #[test]
+    fn init_idempotent() {
+        std::env::remove_var("SENTRY_DSN");
+        let _g1 = init(LoggerConfig {
+            repo: "r1",
+            tool: "t1",
+            sentry_dsn: None,
+            run_id: None,
+        });
+        let _g2 = init(LoggerConfig {
+            repo: "r2",
+            tool: "t2",
+            sentry_dsn: None,
+            run_id: None,
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `wxyc_etl::logger` (Rust) and `wxyc_etl.logger` (Python) for the four-tag contract (`repo`, `tool`, `step`, `run_id`) shared across every WXYC ETL.
- Sentry is wired up when `SENTRY_DSN` is set; without it, JSON logging still initializes and Sentry stays inactive (no-op guard).
- Restructures `wxyc-etl-python` to a mixed Rust/Python maturin layout (`python-source = "python"`, `module-name = "wxyc_etl._native"`) so pure-Python helpers like `logger.py` ship alongside the existing PyO3 submodules.
- Existing imports (`from wxyc_etl import text`, `from wxyc_etl.text import normalize_artist_name`) keep working — all 205 binding tests pass and the wheel-lifecycle smoke test passes.
- Adds an Observability section to `CLAUDE.md` with Rust + Python usage examples.

This is the foundation issue for the Sentry epic; it gates 6 downstream Sentry wireups (`discogs-etl#114`, `musicbrainz-cache#23`, `wikidata-json-filter#13`, `discogs-xml-converter#33`, `semantic-index#198`, `Backend-Service#538`).

Closes #50.

## Test plan

- [x] `cargo test -p wxyc-etl --lib` (353 passed)
- [x] `cargo test -p wxyc-etl --tests` (integration suites pass)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --exclude wxyc-etl-python` with the CI allow-list
- [x] `pytest wxyc-etl-python/tests/` (205 passed)
- [x] `python tests/test_wheel_lifecycle.py` (42 passed)
- [x] `scripts/check_marker_ci_sync.py` still passes
- [ ] CI green