### PR TITLE
Update wikidata-json-filter references to wikidata-cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Cargo workspace with two members:
 
 | Crate | Path | Purpose |
 |---|---|---|
-| `wxyc-etl` | `wxyc-etl/` | Pure Rust library. Used by other Rust ETL repos (discogs-xml-converter, musicbrainz-cache, wikidata-json-filter) via `[dependencies] wxyc-etl = { path = "../wxyc-etl" }`. |
+| `wxyc-etl` | `wxyc-etl/` | Pure Rust library. Used by other Rust ETL repos (discogs-xml-converter, musicbrainz-cache, wikidata-cache) via `[dependencies] wxyc-etl = { path = "../wxyc-etl" }`. |
 | `wxyc-etl-python` | `wxyc-etl-python/` | PyO3 extension that re-exports a curated subset to Python as `wxyc_etl.text`, `wxyc_etl.fuzzy`, `wxyc_etl.parser`, `wxyc_etl.state`, `wxyc_etl.import_utils`, `wxyc_etl.schema`. Built with maturin. |
 
 The Python crate lives in the same workspace so it shares the lockfile with the Rust crate it wraps; this guarantees the bindings always match the underlying library at the byte level.
@@ -209,7 +209,7 @@ Repos that depend on wxyc-etl by Cargo path or via the Python wheel:
 
 - **discogs-xml-converter** (Rust) — `pipeline`, `text`, `csv_writer`
 - **musicbrainz-cache** (Rust) — `pipeline`, `text`, `pg`, `schema`, `state`
-- **wikidata-json-filter** (Rust) — `pipeline`, `csv_writer`
+- **wikidata-cache** (Rust) — `pipeline`, `csv_writer`
 - **discogs-etl** (Python via PyO3) — `text`, `state`, `import_utils`, `parser`, `schema`
 - **semantic-index** (Python via PyO3) — `text`, `fuzzy`, `parser`, `schema`
 

--- a/wxyc-etl/src/csv_writer/mod.rs
+++ b/wxyc-etl/src/csv_writer/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Manages N `csv::Writer` instances (one per output file), each with
 //! pre-written headers. Ported from the per-repo writer patterns in
-//! `discogs-xml-converter/src/writer.rs` and `wikidata-json-filter/src/writer.rs`.
+//! `discogs-xml-converter/src/writer.rs` and `wikidata-cache/src/writer.rs`.
 
 mod writer;
 


### PR DESCRIPTION
## Summary

- Replace stale `wikidata-json-filter` references with `wikidata-cache` in the workspace doc and the `csv_writer` porting comment.
- No code paths or public APIs touched.

## Test plan

- [x] `grep -ri wikidata.json.filter .` returns no matches
- [x] `cargo test --workspace` (all suites green)
- [x] `cargo fmt --check` + `cargo clippy --workspace --all-targets` with the CI allow-list (clean)

Closes #52

Parent: WXYC/wikidata-json-filter#12