### PR TITLE
fix: route wxyc_etl::logger JSON output to stderr

### DIFF
--- a/wxyc-etl/src/logger.rs
+++ b/wxyc-etl/src/logger.rs
@@ -89,11 +89,16 @@ pub fn init(config: LoggerConfig) -> LoggerGuard {
         let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
 
+        // Write to stderr so the contract matches `env_logger` and POSIX
+        // convention: stdout is for the program's data output, stderr is for
+        // diagnostics. Existing tests across consumer repos read stderr for
+        // log lines and break if logs land on stdout instead.
         let json_layer = tracing_subscriber::fmt::layer()
             .json()
             .with_current_span(true)
             .with_span_list(false)
-            .with_target(true);
+            .with_target(true)
+            .with_writer(std::io::stderr);
 
         let registry = tracing_subscriber::registry()
             .with(env_filter)


### PR DESCRIPTION
## Summary

`tracing_subscriber::fmt::layer()` defaults to stdout, but `env_logger` (the predecessor across the WXYC ETLs) writes to stderr. Existing integration tests across consumer repos read stderr for log substrings — under the new logger they were getting empty stderr (logs on stdout instead) and failing.

Wire the JSON layer to `std::io::stderr` to match `env_logger` semantics and the POSIX convention (stdout for data, stderr for diagnostics).

## Surfaced by

[musicbrainz-cache#28](https://github.com/WXYC/musicbrainz-cache/pull/28) (the Sentry wireup PR for musicbrainz-cache) where 3 resume integration tests fail with messages like \`expected log "Skipping Apply schema" on full-resume run. stderr was: [empty]\`. After this lands, that PR can be rebased and CI should turn green.

## Test plan

- [x] \`cargo test -p wxyc-etl --lib logger\` (3 passed)
- [x] \`cargo fmt --check\`
- [ ] CI green
- [ ] Rebase musicbrainz-cache#28 and verify resume tests pass