### PR TITLE
ci: tag-driven release workflow for crates.io + PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,130 @@
+name: Release
+
+# Tag-driven publish for both halves of the wxyc-etl workspace.
+#
+#   git tag v0.1.0 && git push origin v0.1.0
+#
+# A `workflow_dispatch` run with `dry_run: true` (the default) is the safe way
+# to rehearse the pipeline without touching crates.io or PyPI. It runs every
+# build + a `cargo publish --dry-run` and skips the actual upload steps.
+#
+# Required repo secrets (set up once in GitHub → Settings → Secrets):
+#   CRATES_IO_TOKEN   API token from https://crates.io/me — needs `publish-new` + `publish-update` scopes
+#   PYPI_API_TOKEN    API token from https://pypi.org/manage/account/token/ — scope to the `wxyc-etl` project after first publish
+
+on:
+  push:
+    tags: ['v*.*.*']
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Skip cargo/PyPI uploads (rehearsal mode)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: v
+        name: Verify Cargo.toml version matches tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          CARGO_VERSION=$(awk -F'"' '/^version =/ { print $2; exit }' Cargo.toml)
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+            if [[ "$TAG_VERSION" != "$CARGO_VERSION" ]]; then
+              echo "::error ::Tag $TAG_VERSION does not match Cargo.toml workspace version $CARGO_VERSION"
+              exit 1
+            fi
+          fi
+          echo "Workspace version: $CARGO_VERSION"
+          echo "version=$CARGO_VERSION" >> "$GITHUB_OUTPUT"
+
+  publish-crate:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: cargo publish (dry-run)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        run: cargo publish -p wxyc-etl --dry-run
+      - name: cargo publish
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run) }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish -p wxyc-etl
+
+  build-wheels:
+    needs: verify
+    name: wheel ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu,  manylinux: auto }
+          - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, manylinux: auto }
+          - { os: macos-13,      target: x86_64-apple-darwin,       manylinux: '' }
+          - { os: macos-latest,  target: aarch64-apple-darwin,      manylinux: '' }
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux }}
+          working-directory: wxyc-etl-python
+          args: --release --out dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.target }}
+          path: wxyc-etl-python/dist
+
+  build-sdist:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: PyO3/maturin-action@v1
+        with:
+          working-directory: wxyc-etl-python
+          command: sdist
+          args: --out dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: wxyc-etl-python/dist
+
+  publish-pypi:
+    needs: [publish-crate, build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: List artifacts
+        run: ls -la dist/
+      - name: Skip upload (dry-run)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        run: |
+          echo "Dry-run mode: would upload the following artifacts:"
+          ls -la dist/
+      - uses: PyO3/maturin-action@v1
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run) }}
+        with:
+          command: upload
+          args: --skip-existing dist/*
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,43 @@ jobs:
 
 Intentional opt-out for a marker that is, by design, manual-only: add `# ci-sync-skip: <marker> reason: <text>` anywhere in pyproject.toml (the script greps the raw text). See `wxyc-etl-python/pyproject.toml` for a live example (the `perf` marker).
 
+## Releases
+
+Both halves of the workspace publish from the same tag — `wxyc-etl` to crates.io, `wxyc-etl-python` to PyPI. The workspace `version` in the root `Cargo.toml` is the single source of truth; both crates inherit it via `version.workspace = true` and maturin reads it via `pyproject.toml`'s `dynamic = ["version"]`.
+
+### Cutting a release
+
+```bash
+# 1. Bump the workspace version
+$EDITOR Cargo.toml          # change [workspace.package] version
+git commit -am "chore: bump workspace version to 0.X.Y"
+
+# 2. Tag and push
+git tag v0.X.Y
+git push origin main --tags
+```
+
+The `release.yml` workflow fires on tags matching `v*.*.*`. It:
+1. Verifies the tag matches `Cargo.toml`'s workspace version.
+2. `cargo publish -p wxyc-etl` to crates.io.
+3. Builds wheels for `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin` plus an sdist.
+4. `maturin upload --skip-existing dist/*` to PyPI.
+
+### Rehearsing a release
+
+Use the `workflow_dispatch` trigger with `dry_run: true` (the default). It runs every build step + a `cargo publish --dry-run` and skips the actual upload steps. Safe to run any time.
+
+### Required repo secrets
+
+| Secret | Source |
+|---|---|
+| `CRATES_IO_TOKEN` | https://crates.io/me — `publish-new` + `publish-update` scopes |
+| `PYPI_API_TOKEN` | https://pypi.org/manage/account/token/ — scope to the `wxyc-etl` project after the first publish |
+
+### Versioning
+
+Stay in 0.x lockstep until rec 5 (publish) and rec 7 (migrations) both ship; cut 1.0 after that. Hard cuts in 0.x are acceptable; introduce a deprecation cycle post-1.0. See `project_pipeline_hardening` memory for the agreed-upon decisions.
+
 ## Consumers
 
 Repos that depend on wxyc-etl by Cargo path or via the Python wheel:


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/release.yml\` that publishes both halves of the workspace from a single git tag:

- \`cargo publish -p wxyc-etl\` to crates.io
- maturin builds wheels for x86_64 + aarch64 on Linux and macOS plus an sdist, and uploads all artifacts to PyPI in one \`maturin upload --skip-existing\` step

\`workflow_dispatch\` is included with \`dry_run: true\` as the default so the pipeline can be rehearsed end-to-end without touching either registry.

Single source of truth for the version is the workspace \`[workspace.package] version\` in \`Cargo.toml\` — both crates use \`version.workspace = true\` and maturin reads it via \`pyproject.toml\`'s \`dynamic = [\"version\"]\`. The verify job rejects any tag that doesn't match.

Adds a "Releases" section to \`CLAUDE.md\` covering: cut-a-release procedure, dry-run rehearsal, the two required secrets, and the agreed-upon 0.x lockstep + cut-1.0-after-recs-5+7 versioning policy.

This is the Phase B foundation. The six consumer migrations (\`musicbrainz-cache#25\`, \`wikidata-cache#16\`, \`discogs-xml-converter#35\`, \`discogs-etl#117\`, \`semantic-index#200\`, \`wxyc-catalog#21\`) follow once the first release tag publishes cleanly.

Closes #54.

## Operator action required before first release

1. Create \`CRATES_IO_TOKEN\` at https://crates.io/me with \`publish-new\` + \`publish-update\` scopes.
2. Create \`PYPI_API_TOKEN\` at https://pypi.org/manage/account/token/. For the very first publish, scope it project-agnostic; after the package exists, scope it to \`wxyc-etl\` and rotate.
3. Add both as repo secrets at \`https://github.com/WXYC/wxyc-etl/settings/secrets/actions\`.
4. Run the workflow once via \`workflow_dispatch\` with \`dry_run: true\` (the default) to verify the pipeline.
5. Tag and push: \`git tag v0.1.0 && git push origin v0.1.0\` to publish.

## Test plan

- [x] \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/release.yml'))\"\` (YAML parses)
- [x] \`cargo publish -p wxyc-etl --dry-run\` succeeds locally with current Cargo.toml metadata
- [ ] CI green on this PR (lint + existing test + python-wheel)
- [ ] Once secrets are in place, \`workflow_dispatch\` rehearsal run with \`dry_run: true\` succeeds
- [ ] First tag publishes successfully to both registries