### PR TITLE
fix: release workflow — abi3 wheels + drop x86_64 macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,6 @@ jobs:
         include:
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu,  manylinux: auto }
           - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, manylinux: auto }
-          - { os: macos-13,      target: x86_64-apple-darwin,       manylinux: '' }
           - { os: macos-latest,  target: aarch64-apple-darwin,      manylinux: '' }
     runs-on: ${{ matrix.os }}
     steps:
@@ -80,12 +79,17 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      # `-i python3.12` tells maturin which interpreter headers to build against
+      # inside the manylinux container. Combined with the `abi3-py39` feature
+      # on pyo3, the resulting wheel is a single abi3 artifact compatible with
+      # Python 3.9+ on this platform, so we don't fan the matrix out over
+      # Python versions.
       - uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
           working-directory: wxyc-etl-python
-          args: --release --out dist
+          args: --release --out dist -i python3.12
       - uses: actions/upload-artifact@v4
         with:
           name: wheel-${{ matrix.target }}

--- a/wxyc-etl-python/Cargo.toml
+++ b/wxyc-etl-python/Cargo.toml
@@ -8,6 +8,6 @@ name = "_native"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.25", features = ["extension-module"] }
+pyo3 = { version = "0.25", features = ["extension-module", "abi3-py39"] }
 wxyc-etl = { path = "../wxyc-etl" }
 anyhow = "1"


### PR DESCRIPTION
## Summary

Two fixes uncovered by the first dry-run of \`release.yml\`:

1. **Linux wheel build failed** with \`maturin failed: Couldn't find any python interpreters\`. Inside the manylinux Docker container, no \`setup-python\` runs, so the workflow has to pass \`-i python3.12\` explicitly to maturin. Fix is one arg.
2. **macos-13 (Intel) runner stuck queueing** for 11+ minutes — that pool is being deprecated. Drop x86_64-apple-darwin from the matrix; no current consumer needs Intel macOS wheels. Anyone on Intel Macs can still install from the sdist.

To avoid fanning the matrix out per-Python-version, add the \`abi3-py39\` feature to pyo3 in \`wxyc-etl-python/Cargo.toml\`. One wheel per platform now works for Python 3.9–3.13. Matches the existing \`requires-python = \">=3.9\"\` in pyproject.

## Verified

- \`maturin build --release -i python3.12\` locally produces \`wxyc_etl-0.1.0-cp39-abi3-macosx_11_0_arm64.whl\` (the \`cp39-abi3\` tag is the win — single wheel for 3.9+).

## Next

After this lands, re-run the \`workflow_dispatch\` rehearsal with \`dry_run: true\` to confirm all three wheel matrix entries pass. Then we cut \`v0.1.0\`.