### PR TITLE
fix: build aarch64 Linux wheel on native ARM runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,9 +70,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu,  manylinux: auto }
-          - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, manylinux: auto }
-          - { os: macos-latest,  target: aarch64-apple-darwin,      manylinux: '' }
+          - { os: ubuntu-latest,     target: x86_64-unknown-linux-gnu,  manylinux: auto }
+          # Native aarch64 runner: cross-compiling ring from x86_64 hits an
+          # "ARM assembler must define __ARM_ARCH" error because the manylinux
+          # container's cross toolchain isn't fully configured. Native builds
+          # avoid the cross-compile entirely.
+          - { os: ubuntu-24.04-arm,  target: aarch64-unknown-linux-gnu, manylinux: auto }
+          - { os: macos-latest,      target: aarch64-apple-darwin,      manylinux: '' }
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Second iteration on \`release.yml\` after the first dry-run rehearsal. \`verify\`, \`publish-crate\`, \`build-sdist\`, and 2 of 3 wheels passed. The aarch64 Linux wheel failed with:

\`\`\`
ring@0.17.14:  #error \"ARM assembler must define __ARM_ARCH\"
error: failed to run custom build command for \`ring v0.17.14\`
\`\`\`

That's \`ring\`'s ARM assembly build refusing to compile because the cross-compile C toolchain inside the manylinux2014_aarch64 container isn't fully configured (this would happen for any crate with handwritten ARM assembly).

## Fix

Move the aarch64-unknown-linux-gnu matrix entry to GitHub's native \`ubuntu-24.04-arm\` runner. Native ARM build, no cross-compile, \`ring\` (and any future ARM-asm crates) just compile. \`maturin-action\`'s \`manylinux: auto\` still produces a portable \`manylinux2014_aarch64\` wheel — it just runs the manylinux container natively instead of cross-compiling into it.

## Test plan

- [x] YAML parses
- [ ] Re-run \`workflow_dispatch\` rehearsal with \`dry_run: true\` once this lands. Expectations: 3/3 wheels build (linux x86_64, linux aarch64, macos arm64), sdist builds, cargo publish dry-run succeeds, publish-pypi gets skipped.