### PR TITLE
text: fold Greek final-form sigma to medial in normalize_artist_name

### DIFF
--- a/wxyc-etl-python/tests/test_text.py
+++ b/wxyc-etl-python/tests/test_text.py
@@ -23,6 +23,16 @@ from wxyc_etl import text
         # Multi-diacritic Turkish — canonical from @wxyc/shared#81. Note:
         # ı (dotless i) does not decompose under NFKD; only ş is stripped.
         ("Aşıq Altay", "asıq altay"),
+        # Greek sigma variants (WXYC/library-metadata-lookup#168). Final-form
+        # ς (U+03C2) and medial-form σ (U+03C3) are positional variants of
+        # the same letter; they must collapse to σ. Capital Σ (U+03A3) also
+        # lowercases to σ.
+        ("\u03c2", "\u03c3"),
+        ("\u03a3", "\u03c3"),
+        # Identical normalized output regardless of which sigma form ends the
+        # word — that is the property the fold is buying us.
+        ("\u03a3\u03c4\u03b5\u03bb\u03bb\u03ac\u03c2", "\u03c3\u03c4\u03b5\u03bb\u03bb\u03b1\u03c3"),
+        ("\u03a3\u03c4\u03b5\u03bb\u03bb\u03ac\u03c3", "\u03c3\u03c4\u03b5\u03bb\u03bb\u03b1\u03c3"),
     ],
     ids=[
         "lowercase",
@@ -35,6 +45,10 @@ from wxyc_etl import text
         "hermanos_gutierrez",
         "sonido_duenez",
         "asiq_altay",
+        "final_sigma_to_medial",
+        "capital_sigma_to_medial",
+        "greek_word_final_sigma",
+        "greek_word_medial_sigma",
     ],
 )
 def test_normalize_artist_name(input_name, expected):
@@ -56,6 +70,11 @@ def test_normalize_artist_name_none():
         ("  Hermanos Gutiérrez  ", "  Hermanos Gutierrez  "),
         ("Stereolab", "Stereolab"),
         ("", ""),
+        # Greek sigma fold (WXYC/library-metadata-lookup#168): final-form ς
+        # collapses to medial-form σ even in the case-preserving variant.
+        # Capital Σ is preserved here because no case mapping is applied.
+        ("\u03c2", "\u03c3"),
+        ("\u03a3", "\u03a3"),
     ],
 )
 def test_strip_diacritics(input_str, expected):

--- a/wxyc-etl-python/tests/test_text.py
+++ b/wxyc-etl-python/tests/test_text.py
@@ -23,10 +23,9 @@ from wxyc_etl import text
         # Multi-diacritic Turkish — canonical from @wxyc/shared#81. Note:
         # ı (dotless i) does not decompose under NFKD; only ş is stripped.
         ("Aşıq Altay", "asıq altay"),
-        # Greek sigma variants (WXYC/library-metadata-lookup#168). Final-form
-        # ς (U+03C2) and medial-form σ (U+03C3) are positional variants of
-        # the same letter; they must collapse to σ. Capital Σ (U+03A3) also
-        # lowercases to σ.
+        # Greek sigma variants. Final-form ς (U+03C2) and medial-form
+        # σ (U+03C3) are positional variants of the same letter; they must
+        # collapse to σ. Capital Σ (U+03A3) also lowercases to σ.
         ("\u03c2", "\u03c3"),
         ("\u03a3", "\u03c3"),
         # Identical normalized output regardless of which sigma form ends the
@@ -70,9 +69,9 @@ def test_normalize_artist_name_none():
         ("  Hermanos Gutiérrez  ", "  Hermanos Gutierrez  "),
         ("Stereolab", "Stereolab"),
         ("", ""),
-        # Greek sigma fold (WXYC/library-metadata-lookup#168): final-form ς
-        # collapses to medial-form σ even in the case-preserving variant.
-        # Capital Σ is preserved here because no case mapping is applied.
+        # Greek sigma fold: final-form ς collapses to medial-form σ even in
+        # the case-preserving variant. Capital Σ is preserved here because
+        # no case mapping is applied.
         ("\u03c2", "\u03c3"),
         ("\u03a3", "\u03a3"),
     ],

--- a/wxyc-etl/src/text/normalize.rs
+++ b/wxyc-etl/src/text/normalize.rs
@@ -20,9 +20,6 @@ use unicode_normalization::UnicodeNormalization;
 /// stripped = "".join(c for c in nfkd if not unicodedata.combining(c))
 /// return stripped.lower().strip()
 /// ```
-///
-/// The sigma fold is the WXYC/library-metadata-lookup#168 warm-up — see
-/// `fold_sigma`.
 pub fn normalize_artist_name(name: &str) -> String {
     let result = strip_diacritics_and_lowercase(name);
     let trimmed = result.trim_matches(' ');
@@ -78,10 +75,6 @@ fn strip_diacritics_and_lowercase(s: &str) -> String {
 /// sigma (U+03C3 σ). These are positional variants of the same letter and
 /// must hash to the same normalized bucket; default Unicode case mapping
 /// does not collapse them.
-///
-/// This is the WX-2 "warm-up" — it patches the existing normalizer ahead of
-/// the broader normalizer-charter migration in WXYC/docs#16, where this fold
-/// will move into `to_match_form`. See WXYC/library-metadata-lookup#168.
 #[inline]
 fn fold_sigma(c: char) -> char {
     if c == '\u{03C2}' {
@@ -209,7 +202,7 @@ mod tests {
         assert_eq!(normalize_title("Aluminum Tunes"), "aluminum tunes");
     }
 
-    // --- Greek sigma fold (WXYC/library-metadata-lookup#168) ---
+    // --- Greek sigma fold ---
     // Final-form sigma U+03C2 (ς) and medial-form sigma U+03C3 (σ) are
     // positional variants of the same letter and must hash to the same
     // normalized bucket.

--- a/wxyc-etl/src/text/normalize.rs
+++ b/wxyc-etl/src/text/normalize.rs
@@ -1,8 +1,10 @@
 //! Artist and title name normalization.
 //!
 //! Normalizes names using NFKD decomposition with combining character
-//! removal, matching the behavior of `filter_csv.py:normalize_artist()` in
-//! the discogs-cache repo.
+//! removal, derived from `filter_csv.py:normalize_artist()` in the
+//! discogs-cache repo. Diverges in one place: this module also folds the
+//! Greek lowercase final-form sigma (U+03C2 ς) to the medial-form sigma
+//! (U+03C3 σ) — see `fold_sigma`. The Python implementation does not.
 
 use unicode_categories::UnicodeCategories;
 use unicode_normalization::UnicodeNormalization;
@@ -10,13 +12,17 @@ use unicode_normalization::UnicodeNormalization;
 /// Normalize an artist name for matching.
 ///
 /// Applies NFKD decomposition, strips combining characters (diacritics),
-/// lowercases, and trims whitespace. This matches the Python implementation:
+/// lowercases, folds the Greek final-form sigma (U+03C2 ς → U+03C3 σ),
+/// and trims whitespace. The first three steps match this Python:
 ///
 /// ```python
 /// nfkd = unicodedata.normalize("NFKD", name)
 /// stripped = "".join(c for c in nfkd if not unicodedata.combining(c))
 /// return stripped.lower().strip()
 /// ```
+///
+/// The sigma fold is the WXYC/library-metadata-lookup#168 warm-up — see
+/// `fold_sigma`.
 pub fn normalize_artist_name(name: &str) -> String {
     let result = strip_diacritics_and_lowercase(name);
     let trimmed = result.trim_matches(' ');
@@ -30,11 +36,16 @@ pub fn normalize_artist_name(name: &str) -> String {
 /// Strip diacritics via NFKD decomposition without lowercasing or trimming.
 ///
 /// Useful for title normalization contexts where case preservation is needed.
+///
+/// Also folds the Greek lowercase final-form sigma (U+03C2 ς) to the
+/// medial-form sigma (U+03C3 σ) so positional variants of the same letter
+/// hash to the same bucket. Capital sigma (U+03A3 Σ) is preserved here —
+/// it is folded only by the lowercasing path in `normalize_artist_name`.
 pub fn strip_diacritics(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
     for c in s.nfkd() {
         if !c.is_mark() {
-            result.push(c);
+            result.push(fold_sigma(c));
         }
     }
     result
@@ -49,16 +60,35 @@ pub fn normalize_title(title: &str) -> String {
 }
 
 /// NFKD decompose, remove combining marks, and lowercase in a single pass.
+/// Also folds the Greek lowercase final-form sigma (U+03C2 ς) to the
+/// medial-form sigma (U+03C3 σ) — see `fold_sigma`.
 fn strip_diacritics_and_lowercase(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
     for c in s.nfkd() {
         if !c.is_mark() {
             for lc in c.to_lowercase() {
-                result.push(lc);
+                result.push(fold_sigma(lc));
             }
         }
     }
     result
+}
+
+/// Fold the Greek lowercase final-form sigma (U+03C2 ς) to the medial-form
+/// sigma (U+03C3 σ). These are positional variants of the same letter and
+/// must hash to the same normalized bucket; default Unicode case mapping
+/// does not collapse them.
+///
+/// This is the WX-2 "warm-up" — it patches the existing normalizer ahead of
+/// the broader normalizer-charter migration in WXYC/docs#16, where this fold
+/// will move into `to_match_form`. See WXYC/library-metadata-lookup#168.
+#[inline]
+fn fold_sigma(c: char) -> char {
+    if c == '\u{03C2}' {
+        '\u{03C3}'
+    } else {
+        c
+    }
 }
 
 #[cfg(test)]
@@ -177,5 +207,40 @@ mod tests {
         assert_eq!(normalize_title("Hermanos Gutiérrez"), "hermanos gutierrez");
         assert_eq!(normalize_title("  Sugar Hill  "), "sugar hill");
         assert_eq!(normalize_title("Aluminum Tunes"), "aluminum tunes");
+    }
+
+    // --- Greek sigma fold (WXYC/library-metadata-lookup#168) ---
+    // Final-form sigma U+03C2 (ς) and medial-form sigma U+03C3 (σ) are
+    // positional variants of the same letter and must hash to the same
+    // normalized bucket.
+
+    #[test]
+    fn test_normalize_folds_final_sigma_to_medial() {
+        assert_eq!(normalize_artist_name("\u{03C2}"), "\u{03C3}");
+    }
+
+    #[test]
+    fn test_normalize_capital_sigma_lowercases_to_medial() {
+        assert_eq!(normalize_artist_name("\u{03A3}"), "\u{03C3}");
+    }
+
+    #[test]
+    fn test_normalize_greek_word_sigma_variants_collide() {
+        let final_form = "Στελλάς";
+        let medial_form = "Στελλάσ";
+        assert_eq!(
+            normalize_artist_name(final_form),
+            normalize_artist_name(medial_form)
+        );
+    }
+
+    #[test]
+    fn test_strip_diacritics_folds_final_sigma_to_medial() {
+        assert_eq!(strip_diacritics("\u{03C2}"), "\u{03C3}");
+    }
+
+    #[test]
+    fn test_strip_diacritics_preserves_capital_sigma() {
+        assert_eq!(strip_diacritics("\u{03A3}"), "\u{03A3}");
     }
 }


### PR DESCRIPTION
## Summary

- Add a single-char fold of Greek final-form sigma (U+03C2 ς) → medial-form sigma (U+03C3 σ) inside `normalize_artist_name` and `strip_diacritics`.
- Capital Σ already lowercases to medial σ via the existing `to_lowercase` pass; this PR just collapses the lowercase positional variants.
- The case-preserving `strip_diacritics` variant still leaves capital Σ untouched (it does no case mapping by design).

Out-of-band warm-up for the broader normalizer charter (WX-2, WXYC/docs#16). When the charter lands, the fold migrates into `to_match_form` and this site can become a thin alias.

## Why

WXYC's catalog includes Greek-letter artist names (e.g., the V012 mojibake repair pair `Î£tella → Σtella`). After a search for `Στελλάς` is normalized, the trailing final sigma `ς` is left as-is by default Unicode rules, so it hashes to a different bucket than the same word typed with medial sigma at word-end. WXYC/library-metadata-lookup#168 documents the symptom in LML's name normalizer; since LML now consumes `wxyc_etl.text.normalize_artist_name` via the PyO3 wheel, fixing the fold here lifts it everywhere.

## Divergence note

`discogs-etl/scripts/filter_csv.py:normalize_artist` is the historical reference implementation this module was derived from. It does *not* fold sigma. The Rust side now diverges by exactly this one fold. The module-level docstring records the divergence. Reconciliation (either porting the fold to filter_csv.py or replacing both with `to_match_form`) is owned by WX-2; the existing `python_parity` integration tests do not exercise sigma codepoints, so they pass unchanged.

## Test plan

- [x] Failing Rust unit tests for `normalize_artist_name(\"ς\") == \"σ\"`, `normalize_artist_name(\"Σ\") == \"σ\"`, `normalize_artist_name(\"Στελλάς\") == normalize_artist_name(\"Στελλάσ\")`, `strip_diacritics(\"ς\") == \"σ\"`, `strip_diacritics(\"Σ\") == \"Σ\"`.
- [x] Tests turn green after the `fold_sigma` helper is added.
- [x] Full `cargo test --package wxyc-etl` passes (unit + integration + python_parity).
- [x] Python wheel rebuilt with `maturin develop --release` and `pytest` passes (211 tests; +4 sigma cases in `test_normalize_artist_name`, +2 in `test_strip_diacritics`).
- [x] `cargo fmt --check` clean. (Pre-existing clippy `approx_constant` errors in `parser/mysql.rs` are unrelated.)

## Follow-ups (not in this PR)

- WX-2 (WXYC/docs#16) — define `to_match_form` and migrate this fold into it; deprecate `normalize_artist_name`.
- discogs-etl `scripts/filter_csv.py` — port or retire the divergence (covered by WX-2 migration).
- WXYC/library-metadata-lookup#168 — closed by this PR once the next wxyc-etl wheel ships and LML picks it up.

Closes WXYC/library-metadata-lookup#168
Refs WXYC/docs#14, WXYC/docs#16