### PR TITLE
docs(schema/entity): correct framing — entity.identity is live, retarget renamed wiki page

### DIFF
--- a/wxyc-etl/src/schema/entity.rs
+++ b/wxyc-etl/src/schema/entity.rs
@@ -1,10 +1,13 @@
 //! Entity store schema constants.
 //!
-//! Matches the `entity.identity` DDL specified in the WXYC wiki's
-//! `cache-databases.md` (Cross-cutting section). These constants are
-//! placeholders to be finalized when the entity-resolution pipeline lands
-//! (Phase 5 of `metadata-consolidation-2026.md`); that implementation's DDL
-//! is the source of truth.
+//! Mirrors the live `entity.identity` schema in the discogs-cache PG. The
+//! producer is library-metadata-lookup's `scripts/entity_resolution/` —
+//! that pipeline's DDL is the source of truth; these constants exist for
+//! Rust consumers that need to address the same table without hardcoding
+//! names. See the WXYC wiki's `cache-databases.md` (Cross-cutting:
+//! `entity.identity`) for the full producer/consumer story and the
+//! cross-cache-identity follow-on that plans to migrate this table to a
+//! Backend-side `wxyc_schema.library_identity`.
 
 pub const ENTITY_IDENTITY_TABLE: &str = "entity.identity";
 

--- a/wxyc-etl/src/schema/entity.rs
+++ b/wxyc-etl/src/schema/entity.rs
@@ -1,8 +1,10 @@
 //! Entity store schema constants.
 //!
-//! Matches the entity store DDL from the architecture document
-//! (`etl-pipeline-architecture.md`). These constants are placeholders to be
-//! finalized when task 5a is implemented; 5a's DDL is the source of truth.
+//! Matches the `entity.identity` DDL specified in the WXYC wiki's
+//! `cache-databases.md` (Cross-cutting section). These constants are
+//! placeholders to be finalized when the entity-resolution pipeline lands
+//! (Phase 5 of `metadata-consolidation-2026.md`); that implementation's DDL
+//! is the source of truth.
 
 pub const ENTITY_IDENTITY_TABLE: &str = "entity.identity";
 


### PR DESCRIPTION
Closes #76.

## Summary

- Update the module-level doc comment on \`wxyc-etl/src/schema/entity.rs\` to reflect that \`entity.identity\` is **live in production** (not a placeholder awaiting Phase 5a) — that phase shipped.
- Retarget the wiki link: the old \`etl-pipeline-architecture.md\` page was renamed and split (in [WXYC/wiki#6](https://github.com/WXYC/wiki/pull/6)) into \`metadata-infrastructure.md\` + \`cache-databases.md\` + \`metadata-consolidation-2026.md\`. The new comment points at the right successor (\`cache-databases.md\` cross-cutting section) and names the cross-cache-identity follow-on.
- The Rust constants themselves are unchanged — they already match the live schema.

Docs-only, single-file diff (~8 lines net).

## Test plan

- [x] \`cargo fmt --check\` clean.
- [x] \`cargo clippy --workspace --all-targets\` clean against the CI allow-list.
- [x] \`cargo test --workspace\` passes.
- [ ] CI green on the PR.