### PR TITLE
text: add to_match_form (WX-2.2.2)

### DIFF
--- a/wxyc-etl/src/text/folds.rs
+++ b/wxyc-etl/src/text/folds.rs
@@ -1,0 +1,110 @@
+//! WXYC fold registry — script-aware folds that go beyond what default
+//! Unicode case-mapping covers.
+//!
+//! Charter design: WX-2.1.2 in `plans/mojibake-prevention/2-normalizer-charter.md`.
+//! Each entry here is a deliberate, human-reviewed choice; this is the only
+//! place in the normalizer where casual cultural decisions live.
+//!
+//! ## Folds
+//!
+//! - **U+03C2 ς → U+03C3 σ** (Greek final sigma → medial sigma). Positional
+//!   variants of the same letter; default Unicode lowercasing maps capital
+//!   Σ → σ but does not collapse ς into σ. Without this, `Στελλάς` and
+//!   `Στελλάσ` hash to different match-form buckets.
+//! - **U+00E6 æ → "ae"** (Latin small ligature). Treated as the two-letter
+//!   sequence its Latin-script readers expect to type. Norwegian / Danish /
+//!   Old English usage.
+//! - **U+0153 œ → "oe"** (Latin small ligature). Same rationale as æ.
+//!   French / Old English usage.
+//!
+//! ## Non-folds (intentionally preserved)
+//!
+//! - **U+0142 ł, U+0141 Ł** (Polish). Not a diacritic on a Latin base —
+//!   the bar through the L is part of the letter's identity.
+//! - **U+00F8 ø, U+00D8 Ø** (Norwegian / Danish). Same: the slash is
+//!   part of the letter, not decoration on `o`.
+//! - **U+0131 ı, U+0130 İ** (Turkish dotless / dotted i). Distinct letters
+//!   in Turkish phonology; folding ı→i would mis-match Turkish names.
+//!
+//! These non-folds are what callers see. ASCII transliteration that
+//! collapses them (ł → l, ø → o, ı → i) belongs in `to_ascii_form`, not here.
+
+/// Apply the WXYC fold registry to `s`. See module docs for the list.
+///
+/// Pre-scans for trigger codepoints so the common case (no fold needed)
+/// returns the input unchanged without an extra allocation.
+pub fn apply_folds(s: &str) -> String {
+    if !s.chars().any(is_fold_trigger) {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\u{03C2}' => out.push('\u{03C3}'),
+            '\u{00E6}' => out.push_str("ae"),
+            '\u{0153}' => out.push_str("oe"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[inline]
+fn is_fold_trigger(c: char) -> bool {
+    matches!(c, '\u{03C2}' | '\u{00E6}' | '\u{0153}')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folds_final_sigma_to_medial() {
+        assert_eq!(apply_folds("\u{03C2}"), "\u{03C3}");
+    }
+
+    #[test]
+    fn folds_ae_ligature_to_ae() {
+        assert_eq!(apply_folds("\u{00E6}"), "ae");
+        assert_eq!(apply_folds("encyclop\u{00E6}dia"), "encyclopaedia");
+    }
+
+    #[test]
+    fn folds_oe_ligature_to_oe() {
+        assert_eq!(apply_folds("\u{0153}"), "oe");
+        assert_eq!(apply_folds("c\u{0153}ur"), "coeur");
+    }
+
+    #[test]
+    fn preserves_polish_l_with_stroke() {
+        // Non-fold: ł stays ł.
+        assert_eq!(apply_folds("\u{0142}ukasz"), "\u{0142}ukasz");
+    }
+
+    #[test]
+    fn preserves_norwegian_o_with_stroke() {
+        assert_eq!(apply_folds("\u{00F8}ster"), "\u{00F8}ster");
+    }
+
+    #[test]
+    fn preserves_turkish_dotless_i() {
+        assert_eq!(apply_folds("a\u{0131}"), "a\u{0131}");
+    }
+
+    #[test]
+    fn passes_through_when_no_trigger() {
+        // Fast path: no allocation expected, but we only assert equality.
+        assert_eq!(apply_folds("stereolab"), "stereolab");
+        assert_eq!(apply_folds(""), "");
+        assert_eq!(
+            apply_folds("\u{03C3}\u{03C4}\u{03B5}\u{03BB}\u{03BB}\u{03B1}"),
+            "\u{03C3}\u{03C4}\u{03B5}\u{03BB}\u{03BB}\u{03B1}"
+        );
+    }
+
+    #[test]
+    fn passes_through_medial_sigma() {
+        // Medial sigma is the canonical bucket; no trigger.
+        assert_eq!(apply_folds("\u{03C3}"), "\u{03C3}");
+    }
+}

--- a/wxyc-etl/src/text/forms.rs
+++ b/wxyc-etl/src/text/forms.rs
@@ -6,13 +6,15 @@
 //!
 //! Currently implemented:
 //! - [`to_storage_form`] (WX-2.2.1)
+//! - [`to_match_form`] (WX-2.2.2)
 //!
 //! Planned:
-//! - `to_match_form` (WX-2.2.2)
 //! - `to_ascii_form` (WX-2.2.3)
 
+use unicode_categories::UnicodeCategories;
 use unicode_normalization::UnicodeNormalization;
 
+use super::folds::apply_folds;
 use super::mojibake::fix_mojibake;
 
 /// Canonical bytes to *store*. Caller should write the return value to
@@ -38,6 +40,117 @@ pub fn to_storage_form(s: &str) -> String {
     } else {
         trimmed.to_string()
     }
+}
+
+/// Equivalence-class form for *comparison*. Caller normalizes both sides
+/// of a comparison through this; the return value is **never stored**.
+///
+/// Pipeline:
+/// 1. [`to_storage_form`] — equivalence is computed against canonical bytes.
+/// 2. NFKC compatibility composition (folds half-width / full-width,
+///    micro-sign U+00B5 → Greek µ, ligatures with compat decomposition).
+/// 3. Default Unicode lowercasing (`char::to_lowercase`). Covers Σ → σ,
+///    Ё → ё, É → é, etc. Eszett ß is preserved (lowercase identity);
+///    if a future need arises, swap in the `caseless` crate for
+///    Default Caseless TR#31 case-folding.
+/// 4. Strip combining marks **selectively**: NFD-decompose, drop combining
+///    marks only when the preceding base codepoint is in Latin or Greek
+///    script, then re-NFC. Cyrillic Ё/Й-style script-essential
+///    diaeresis / breve survive; Latin é / ñ and Greek ά become e / n / α.
+/// 5. Apply WXYC fold registry (see [`super::folds`]): final-sigma ς → σ,
+///    æ → ae, œ → oe.
+/// 6. Strip Cf format characters **except** U+200D ZWJ (preserved so emoji
+///    sequences like 👨‍👩‍👧‍👦 stay intact). LRM/RLM/RLO/PDF and
+///    isolate marks all go.
+/// 7. Collapse runs of ASCII space (U+0020) to a single space; trim leading
+///    and trailing ASCII space. Other whitespace (TAB, etc.) is preserved
+///    for round-trip fidelity to the original input.
+///
+/// Cross-script transliteration (Σ → S, я → ya) is **not** performed here;
+/// that is `to_ascii_form`'s job.
+///
+/// Idempotent: `to_match_form(to_match_form(s)) == to_match_form(s)`.
+pub fn to_match_form(s: &str) -> String {
+    let storage = to_storage_form(s);
+    let nfkc: String = storage.nfkc().collect();
+    let lower: String = nfkc.chars().flat_map(char::to_lowercase).collect();
+    let stripped = strip_combining_selective(&lower);
+    let folded = apply_folds(&stripped);
+    let cf_stripped = strip_cf_except_zwj(&folded);
+    collapse_and_trim_ascii_space(&cf_stripped)
+}
+
+/// NFD-decompose, drop combining marks whose base is Latin or Greek, then
+/// re-NFC. Bases in scripts where a diacritic carries lexical weight
+/// (Cyrillic Ё/Й, etc.) keep their marks.
+fn strip_combining_selective(s: &str) -> String {
+    let mut buf = String::with_capacity(s.len());
+    let mut prev_base: Option<char> = None;
+    for c in s.nfd() {
+        if c.is_mark() {
+            if matches!(prev_base, Some(b) if is_diacritic_decoration_script(b)) {
+                continue;
+            }
+            buf.push(c);
+        } else {
+            buf.push(c);
+            prev_base = Some(c);
+        }
+    }
+    buf.nfc().collect()
+}
+
+/// Scripts where a combining diacritic on a base letter is decoration, not
+/// a distinct letter — safe to strip during match-form folding. Latin
+/// (incl. all Latin Extended blocks) and Greek (incl. Greek Extended).
+///
+/// Cyrillic, Hebrew, Arabic, CJK, and supplementary-plane scripts are
+/// excluded: their combining marks (Cyrillic diaeresis on Е → Ё; Hebrew
+/// niqqud; Arabic tashkil) carry phonemic weight.
+fn is_diacritic_decoration_script(c: char) -> bool {
+    let cp = c as u32;
+    cp <= 0x024F                          // Basic Latin..Latin Extended-B
+        || (0x1E00..=0x1EFF).contains(&cp) // Latin Extended Additional
+        || (0x2C60..=0x2C7F).contains(&cp) // Latin Extended-C
+        || (0xA720..=0xA7FF).contains(&cp) // Latin Extended-D
+        || (0xAB30..=0xAB6F).contains(&cp) // Latin Extended-E
+        || (0x0370..=0x03FF).contains(&cp) // Greek and Coptic
+        || (0x1F00..=0x1FFF).contains(&cp) // Greek Extended
+}
+
+/// Drop Unicode Cf (format) characters, except U+200D ZWJ which carries
+/// emoji-sequence semantics.
+fn strip_cf_except_zwj(s: &str) -> String {
+    if !s.chars().any(|c| c != '\u{200D}' && c.is_other_format()) {
+        return s.to_string();
+    }
+    s.chars()
+        .filter(|&c| c == '\u{200D}' || !c.is_other_format())
+        .collect()
+}
+
+/// Collapse runs of ASCII space (U+0020) to a single space; trim leading
+/// and trailing ASCII space. Other whitespace (TAB U+0009, etc.) is left
+/// alone — `tab\there` remains `tab\there` because TSV column-boundary
+/// hazards are intentional probes, not noise to scrub.
+fn collapse_and_trim_ascii_space(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_space = true;
+    for c in s.chars() {
+        if c == ' ' {
+            if !prev_space {
+                out.push(' ');
+                prev_space = true;
+            }
+        } else {
+            out.push(c);
+            prev_space = false;
+        }
+    }
+    if out.ends_with(' ') {
+        out.pop();
+    }
+    out
 }
 
 #[cfg(test)]
@@ -94,5 +207,109 @@ mod tests {
         let nfd = "n\u{0303}";
         let nfc = "\u{00F1}";
         assert_eq!(to_storage_form(nfd), nfc);
+    }
+
+    // --- to_match_form ---
+
+    #[test]
+    fn match_form_lowercases_and_strips_latin_diacritics() {
+        assert_eq!(to_match_form("Hermanos Gutiérrez"), "hermanos gutierrez");
+        assert_eq!(to_match_form("NILÜFER YANYA"), "nilufer yanya");
+    }
+
+    #[test]
+    fn match_form_folds_greek_capital_sigma_to_medial() {
+        assert_eq!(to_match_form("\u{03A3}tella"), "\u{03C3}tella");
+    }
+
+    #[test]
+    fn match_form_folds_greek_final_sigma_to_medial() {
+        // ς and σ must collide on the same bucket (LML#168).
+        assert_eq!(to_match_form("Στελλάς"), to_match_form("Στελλάσ"));
+        assert_eq!(to_match_form("Στελλάς"), "στελλασ");
+    }
+
+    #[test]
+    fn match_form_preserves_cyrillic_yo_diaeresis() {
+        // Cyrillic Ё must NOT decompose+strip to "е" — script-essential mark.
+        assert_eq!(to_match_form("\u{0401}"), "\u{0451}");
+    }
+
+    #[test]
+    fn match_form_strips_bidi_format_chars() {
+        assert_eq!(to_match_form("Hello\u{200E}World"), "helloworld");
+        assert_eq!(to_match_form("Hello\u{200F}World"), "helloworld");
+        assert_eq!(to_match_form("\u{202E}Reversed\u{202C}"), "reversed");
+    }
+
+    #[test]
+    fn match_form_preserves_zwj_in_emoji_sequence() {
+        // U+200D ZWJ is the only Cf char that survives — emoji integrity.
+        let family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}";
+        assert_eq!(to_match_form(family), family);
+    }
+
+    #[test]
+    fn match_form_repairs_mojibake_then_folds() {
+        // to_storage_form runs first, so mojibake is fixed before folding.
+        assert_eq!(to_match_form("Î£tella"), "\u{03C3}tella");
+        assert_eq!(to_match_form("Ã©"), "e");
+        assert_eq!(to_match_form("â€™"), "\u{2019}");
+    }
+
+    #[test]
+    fn match_form_preserves_polish_l_and_norwegian_o() {
+        // Non-folds: ł and ø stay (they are letters, not decorated bases).
+        assert_eq!(to_match_form("\u{0141}ukasz"), "\u{0142}ukasz");
+        assert_eq!(to_match_form("\u{00D8}ster"), "\u{00F8}ster");
+    }
+
+    #[test]
+    fn match_form_preserves_turkish_dotless_i() {
+        assert_eq!(to_match_form("Aşıq Altay"), "asıq altay");
+    }
+
+    #[test]
+    fn match_form_preserves_cjk_emoji_arabic() {
+        assert_eq!(to_match_form("細野晴臣"), "細野晴臣");
+        assert_eq!(to_match_form("🎵"), "🎵");
+        assert_eq!(to_match_form("فيروز"), "فيروز");
+    }
+
+    #[test]
+    fn match_form_collapses_runs_of_ascii_space() {
+        assert_eq!(to_match_form("  Molchat   Doma  "), "molchat doma");
+    }
+
+    #[test]
+    fn match_form_preserves_embedded_tab() {
+        // TAB is intentional probe data, not whitespace to scrub.
+        assert_eq!(to_match_form("tab\there"), "tab\there");
+    }
+
+    #[test]
+    fn match_form_idempotent() {
+        for s in [
+            "Stereolab",
+            "Hermanos Gutiérrez",
+            "Στελλάς",
+            "細野晴臣",
+            "🎵",
+            "Î£tella",
+            "Hello\u{200E}World",
+            "\u{0401}", // Cyrillic Ё
+            "\u{1F468}\u{200D}\u{1F469}",
+        ] {
+            assert_eq!(
+                to_match_form(&to_match_form(s)),
+                to_match_form(s),
+                "idempotence broken for {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn match_form_empty() {
+        assert_eq!(to_match_form(""), "");
     }
 }

--- a/wxyc-etl/src/text/mod.rs
+++ b/wxyc-etl/src/text/mod.rs
@@ -12,6 +12,7 @@
 pub mod batch;
 pub mod compilation;
 pub mod filter;
+pub mod folds;
 pub mod forms;
 pub mod mojibake;
 pub mod normalize;
@@ -21,7 +22,7 @@ pub mod split;
 pub use batch::{batch_filter, batch_normalize};
 pub use compilation::{is_compilation_artist, COMPILATION_KEYWORDS};
 pub use filter::{ArtistFilter, TitleFilter};
-pub use forms::to_storage_form;
+pub use forms::{to_match_form, to_storage_form};
 pub use mojibake::fix_mojibake;
 pub use normalize::{normalize_artist_name, normalize_title, strip_diacritics};
 pub use split::{split_artist_name, split_artist_name_contextual};

--- a/wxyc-etl/tests/forms_match.rs
+++ b/wxyc-etl/tests/forms_match.rs
@@ -1,0 +1,63 @@
+//! WX-2.2.2 acceptance test for `to_match_form`.
+//!
+//! Drives every entry of the WX-1 charset-torture corpus that defines an
+//! `expected_match_form` through `wxyc_etl::text::to_match_form` and asserts
+//! the result equals it. Companion to `tests/forms_storage.rs` and the
+//! legacy `tests/charset_torture.rs` (which still exercises the
+//! pre-charter `normalize_artist_name` and carries `[etl:no-match-form]`
+//! xfails until M2.2.5 deprecates that path).
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct CorpusEntry {
+    input: String,
+    expected_match_form: Option<String>,
+    notes: String,
+}
+
+#[derive(Deserialize)]
+struct Corpus {
+    categories: HashMap<String, Vec<CorpusEntry>>,
+}
+
+fn load_corpus() -> Corpus {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests/fixtures/charset-torture.json");
+    let bytes = std::fs::read(&path).expect("vendored corpus exists");
+    serde_json::from_slice(&bytes).expect("corpus is valid JSON")
+}
+
+#[test]
+fn corpus_match_form_compliance() {
+    let corpus = load_corpus();
+    let mut failures: Vec<String> = Vec::new();
+
+    for (category, entries) in &corpus.categories {
+        for entry in entries {
+            let Some(expected) = entry.expected_match_form.as_deref() else {
+                continue;
+            };
+            let actual = wxyc_etl::text::to_match_form(&entry.input);
+            if actual != expected {
+                failures.push(format!(
+                    "{category}: {input:?} -> {actual:?}, expected {expected:?}\n    notes: {notes}",
+                    input = entry.input,
+                    notes = entry.notes,
+                ));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "\nto_match_form failures ({}):\n  {}\n",
+        failures.len(),
+        failures.join("\n  ")
+    );
+}


### PR DESCRIPTION
Closes #83.

Implements `wxyc_etl::text::to_match_form` and the WXYC fold registry per the WX-2 normalizer charter. Companion to `to_storage_form` (#82) and the third leg `to_ascii_form` (#84).

## Pipeline

1. `to_storage_form` — equivalence is computed against canonical bytes (mojibake fix + NFC + trim).
2. NFKC compatibility composition.
3. Default Unicode lowercasing (`char::to_lowercase`). Eszett ß is the known gap; swap in the `caseless` crate at the lowercase site if a real case surfaces.
4. **Selective combining-mark stripping**: NFD-decompose, drop combining marks only when the preceding base codepoint is in Latin or Greek script, then re-NFC. Cyrillic Ё / Й keep their script-essential diaeresis / breve; Latin é / ñ and Greek ά become e / n / α. The xfail comment in `tests/charset_torture.rs` predicted this needed a charter decision; the registry lives in `is_diacritic_decoration_script()` in `forms.rs`.
5. Fold registry (`text/folds.rs`): final-sigma ς → σ, æ → ae, œ → oe. Non-folds (Ł, ø, ı) are documented preserves with reasoning so future maintainers do not "fix" them.
6. Strip Cf format characters **except** U+200D ZWJ. LRM/RLM/RLO/PDF and isolate marks all go; ZWJ survives so `👨‍👩‍👧‍👦` stays intact.
7. Collapse runs of ASCII space (U+0020) to a single space; trim leading/trailing ASCII space. Other whitespace (TAB, etc.) is preserved — TSV column-boundary hazards are intentional probes, not noise.

Cross-script transliteration (Σ → S, я → ya) is **not** performed; that is `to_ascii_form`'s job (#84).

## Acceptance

- New `tests/forms_match.rs` drives every entry in `wxyc-shared/charset-torture.json` whose `expected_match_form` is non-null through `to_match_form` and asserts equality. Includes the 3 bidi_marks entries (`Hello‎World` → `helloworld`, `Hello‏World` → `helloworld`, `‮Reversed‬` → `reversed`) populated in @wxyc/shared v0.12.0.
- Unit tests in `forms.rs` cover sigma collision (LML#168), Cyrillic Ё preservation, mojibake-then-fold, ZWJ-in-emoji-sequence preservation, ASCII-space collapse, TAB preservation, idempotence, and empty input.
- Idempotence: `to_match_form(to_match_form(s)) == to_match_form(s)` asserted over a representative set including mojibake input, ZWJ sequences, and Cyrillic precomposed forms.

## What this does NOT do

- **No PyO3 binding.** Deferred to #85 (WX-2.2.4). Rust-only callers can use the new entry point today; Python consumers wait for the next slice.
- **No deprecation of legacy `normalize_artist_name` / `strip_diacritics` / `normalize_title`.** Deferred to #86 (WX-2.2.5). The 3 `[etl:no-match-form]` xfails in `tests/charset_torture.rs` stay until that lands — the legacy detector calls `normalize_artist_name`, not `to_match_form`, so flipping them now would just mask which path is being tested.

## Test plan

- [x] `cargo test -p wxyc-etl` — all 412 lib + 50+ integration tests pass.
- [x] `cargo fmt --check` clean on changed files.
- [x] `cargo clippy` clean on changed files (pre-existing diagnostics in `pipeline/runner.rs` are unrelated to this PR).
- [x] Corpus acceptance: every `expected_match_form` in `charset-torture.json` matches `to_match_form(input)`.