### PR TITLE
text: add to_ascii_form (WX-2.2.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3133,6 +3139,7 @@ dependencies = [
  "clap",
  "crossbeam-channel",
  "csv",
+ "deunicode",
  "env_logger",
  "itoa",
  "log",

--- a/wxyc-etl/Cargo.toml
+++ b/wxyc-etl/Cargo.toml
@@ -9,6 +9,7 @@ description = "Shared ETL crate for the WXYC music data pipeline"
 # text module
 unicode-normalization = "0.1"
 unicode_categories = "0.1"
+deunicode = "1"
 
 # pg module
 postgres = "0.19"

--- a/wxyc-etl/src/text/forms.rs
+++ b/wxyc-etl/src/text/forms.rs
@@ -7,10 +7,9 @@
 //! Currently implemented:
 //! - [`to_storage_form`] (WX-2.2.1)
 //! - [`to_match_form`] (WX-2.2.2)
-//!
-//! Planned:
-//! - `to_ascii_form` (WX-2.2.3)
+//! - [`to_ascii_form`] (WX-2.2.3)
 
+use deunicode::deunicode;
 use unicode_categories::UnicodeCategories;
 use unicode_normalization::UnicodeNormalization;
 
@@ -78,6 +77,43 @@ pub fn to_match_form(s: &str) -> String {
     let folded = apply_folds(&stripped);
     let cf_stripped = strip_cf_except_zwj(&folded);
     collapse_and_trim_ascii_space(&cf_stripped)
+}
+
+/// Last-resort ASCII reduction. Use only when [`to_match_form`] produced no
+/// candidates and the caller wants a maximally lenient cross-script search.
+///
+/// Pipeline:
+/// 1. [`to_match_form`] (gives canonical, NFKC, lowercase, fold-applied input).
+/// 2. Strip Symbol-Other codepoints (`So`) — emoji, music symbols, dingbats —
+///    *before* transliteration so 🎸 disappears instead of becoming "guitar".
+/// 3. WXYC Cyrillic Ё/ё override: deunicode renders these as "Io"/"io" but the
+///    common English transliteration is "Yo"/"yo" (Yot, jot). Pre-substitute.
+/// 4. [`deunicode::deunicode`]: Latin transliteration via a ~100 KB compiled-in
+///    table (Greek Σ → S, Cyrillic я → ya, ц → ts, CJK 繭 → Mao).
+/// 5. Lowercase the deunicode output (transliteration restores case).
+/// 6. Strip non-ASCII residue (anything deunicode could not transliterate).
+/// 7. Collapse runs of ASCII space; trim. TAB and other ASCII control bytes
+///    are preserved (same rule as [`to_match_form`]).
+///
+/// **Lossy in both directions.** `to_ascii_form("繭")` (kanji "cocoon") and
+/// `to_ascii_form("Mao")` (the romanization of a person's name) collide on
+/// `"mao"`. Search relevance must rank `to_match_form` matches above
+/// `to_ascii_form` matches.
+pub fn to_ascii_form(s: &str) -> String {
+    let matched = to_match_form(s);
+    let pre: String = matched
+        .chars()
+        .filter(|c| !c.is_symbol_other())
+        .flat_map(|c| match c {
+            '\u{0401}' => "Yo".chars().collect::<Vec<_>>(),
+            '\u{0451}' => "yo".chars().collect::<Vec<_>>(),
+            other => vec![other],
+        })
+        .collect();
+    let translit = deunicode(&pre);
+    let lowered: String = translit.chars().flat_map(char::to_lowercase).collect();
+    let ascii: String = lowered.chars().filter(|c| c.is_ascii()).collect();
+    collapse_and_trim_ascii_space(&ascii)
 }
 
 /// NFD-decompose, drop combining marks whose base is Latin or Greek, then
@@ -311,5 +347,78 @@ mod tests {
     #[test]
     fn match_form_empty() {
         assert_eq!(to_match_form(""), "");
+    }
+
+    // --- to_ascii_form ---
+
+    #[test]
+    fn ascii_form_lml_168_sigma_to_s() {
+        // The motivating case: "Στella" reduces to "stella" so a typed
+        // "Stella" can find the canonical entry through the ASCII fallback.
+        assert_eq!(to_ascii_form("\u{03A3}tella"), "stella");
+        assert_eq!(to_ascii_form("Στελλάς"), "stellas");
+    }
+
+    #[test]
+    fn ascii_form_cyrillic_yo_overrides_deunicode_io() {
+        // deunicode renders Ё/ё as "Io"/"io"; WXYC convention is "Yo"/"yo".
+        assert_eq!(to_ascii_form("\u{0401}"), "yo");
+        assert_eq!(to_ascii_form("\u{0451}"), "yo");
+    }
+
+    #[test]
+    fn ascii_form_strips_emoji_instead_of_describing_them() {
+        // deunicode would render 🎸 as "guitar"; we strip Symbol-Other first.
+        assert_eq!(to_ascii_form("Stereolab \u{1F3B8}"), "stereolab");
+        assert_eq!(to_ascii_form("\u{1F3B5}"), "");
+    }
+
+    #[test]
+    fn ascii_form_transliterates_cyrillic() {
+        assert_eq!(to_ascii_form("Молчат Дома"), "molchat doma");
+        assert_eq!(to_ascii_form("Аукцыон"), "auktsyon");
+    }
+
+    #[test]
+    fn ascii_form_strips_latin_diacritics_via_match_form() {
+        assert_eq!(to_ascii_form("Hermanos Gutiérrez"), "hermanos gutierrez");
+        assert_eq!(to_ascii_form("Sigur Rós"), "sigur ros");
+    }
+
+    #[test]
+    fn ascii_form_repairs_mojibake_then_transliterates() {
+        // Mojibake is fixed by the to_storage_form leg of to_match_form.
+        assert_eq!(to_ascii_form("Î£tella"), "stella");
+        assert_eq!(to_ascii_form("Ã©"), "e");
+    }
+
+    #[test]
+    fn ascii_form_preserves_embedded_tab() {
+        // Same rule as to_match_form: TAB is intentional probe data.
+        assert_eq!(to_ascii_form("tab\there"), "tab\there");
+    }
+
+    #[test]
+    fn ascii_form_idempotent() {
+        for s in [
+            "Stereolab",
+            "Hermanos Gutiérrez",
+            "Στελλάς",
+            "Молчат Дома",
+            "Î£tella",
+            "Stereolab \u{1F3B8}",
+            "\u{0401}",
+        ] {
+            assert_eq!(
+                to_ascii_form(&to_ascii_form(s)),
+                to_ascii_form(s),
+                "idempotence broken for {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ascii_form_empty() {
+        assert_eq!(to_ascii_form(""), "");
     }
 }

--- a/wxyc-etl/src/text/mod.rs
+++ b/wxyc-etl/src/text/mod.rs
@@ -22,7 +22,7 @@ pub mod split;
 pub use batch::{batch_filter, batch_normalize};
 pub use compilation::{is_compilation_artist, COMPILATION_KEYWORDS};
 pub use filter::{ArtistFilter, TitleFilter};
-pub use forms::{to_match_form, to_storage_form};
+pub use forms::{to_ascii_form, to_match_form, to_storage_form};
 pub use mojibake::fix_mojibake;
 pub use normalize::{normalize_artist_name, normalize_title, strip_diacritics};
 pub use split::{split_artist_name, split_artist_name_contextual};

--- a/wxyc-etl/tests/forms_ascii.rs
+++ b/wxyc-etl/tests/forms_ascii.rs
@@ -1,0 +1,65 @@
+//! WX-2.2.3 acceptance test for `to_ascii_form`.
+//!
+//! Drives every entry of the WX-1 charset-torture corpus that defines a
+//! non-null `expected_ascii_form` through `wxyc_etl::text::to_ascii_form`
+//! and asserts the result equals it. Companion to `tests/forms_storage.rs`
+//! and `tests/forms_match.rs`.
+//!
+//! Entries with `expected_ascii_form: null` (CJK, Arabic, Hebrew, raw
+//! emoji rendered as music symbols) are skipped — those scripts have no
+//! committed v1 transliteration.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct CorpusEntry {
+    input: String,
+    expected_ascii_form: Option<String>,
+    notes: String,
+}
+
+#[derive(Deserialize)]
+struct Corpus {
+    categories: HashMap<String, Vec<CorpusEntry>>,
+}
+
+fn load_corpus() -> Corpus {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests/fixtures/charset-torture.json");
+    let bytes = std::fs::read(&path).expect("vendored corpus exists");
+    serde_json::from_slice(&bytes).expect("corpus is valid JSON")
+}
+
+#[test]
+fn corpus_ascii_form_compliance() {
+    let corpus = load_corpus();
+    let mut failures: Vec<String> = Vec::new();
+
+    for (category, entries) in &corpus.categories {
+        for entry in entries {
+            let Some(expected) = entry.expected_ascii_form.as_deref() else {
+                continue;
+            };
+            let actual = wxyc_etl::text::to_ascii_form(&entry.input);
+            if actual != expected {
+                failures.push(format!(
+                    "{category}: {input:?} -> {actual:?}, expected {expected:?}\n    notes: {notes}",
+                    input = entry.input,
+                    notes = entry.notes,
+                ));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "\nto_ascii_form failures ({}):\n  {}\n",
+        failures.len(),
+        failures.join("\n  ")
+    );
+}


### PR DESCRIPTION
Closes #84.

Third and last form in the WX-2 normalizer charter. Pipeline:

1. \`to_match_form\` — gives canonical, NFKC, lowercase, fold-applied input.
2. Strip Symbol-Other (\`So\`) codepoints **before** transliteration so 🎸 vanishes instead of becoming \"guitar\".
3. WXYC Cyrillic Ё/ё override — deunicode renders these as \"Io\"/\"io\"; the common English transliteration is \"Yo\"/\"yo\". Pre-substitute.
4. \`deunicode::deunicode\` for Latin transliteration (Greek Σ→S, Cyrillic я→ya, ц→ts).
5. Lowercase the deunicode output (transliteration restores case).
6. Strip non-ASCII residue.
7. Collapse runs of ASCII space; trim. TAB is preserved (same rule as \`to_match_form\`).

## Acceptance

- All 40 non-null \`expected_ascii_form\` entries in the v0.12.0 charset-torture corpus pass — \`tests/forms_ascii.rs\`.
- 9 new unit tests in \`forms.rs\`: LML#168 \"Στella\"→\"stella\" spot-check, Cyrillic Ё override, emoji-strip-not-describe, Cyrillic transliteration, Latin diacritic strip via match-form, mojibake repair, embedded TAB preservation, idempotence loop, empty input.
- 421 existing wxyc-etl unit tests + storage/match corpus tests still green.

## Wheel-size impact

\`deunicode\` v1.6.2 ships its transliteration table as \`mapping.txt\` (55 KB) + \`pointers.bin\` (410 KB), both \`include_*!()\`'d into the binary — **~465 KB compiled-in data**.

This exceeds the issue's <200 KB target. The plan and the upstream crate docs both anchor on \"~100 KB\"; the actual data is larger. Two options if we care:
- Accept it. \`to_ascii_form\` is a last-resort search fallback; 465 KB is small relative to the existing PyO3 wheel (\~2 MB on macOS-arm64).
- Swap to \`unidecode\` (or hand-roll a narrower script registry) in a follow-up.

Recommendation: ship as-is, file a follow-up if the wheel size becomes a problem when \#85 lands the PyO3 bindings.

## What's deferred

- PyO3 binding + Python parity tests → #85.
- Deprecate legacy \`normalize_artist_name\` / \`strip_diacritics\` / \`normalize_title\` and retire the \`[etl:no-storage-form]\` / \`[etl:no-match-form]\` / (now also) ascii xfails in \`tests/charset_torture.rs\` → #86.
- Cut a release with the new API → #87.

## Test plan

- [x] \`cargo test -p wxyc-etl\` green (incl. the new \`tests/forms_ascii.rs\` corpus driver).
- [x] \`cargo fmt --check\` green.
- [x] No new clippy warnings on \`forms.rs\` / \`forms_ascii.rs\`.