### PR TITLE
python: PyO3 bindings + parity tests for WX-2 forms (WX-2.2.4)

### DIFF
--- a/wxyc-etl-python/src/text.rs
+++ b/wxyc-etl-python/src/text.rs
@@ -9,6 +9,12 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(is_compilation_artist, m)?)?;
     m.add_function(wrap_pyfunction!(split_artist_name, m)?)?;
     m.add_function(wrap_pyfunction!(split_artist_name_contextual, m)?)?;
+    m.add_function(wrap_pyfunction!(to_storage_form, m)?)?;
+    m.add_function(wrap_pyfunction!(to_match_form, m)?)?;
+    m.add_function(wrap_pyfunction!(to_ascii_form, m)?)?;
+    m.add_function(wrap_pyfunction!(batch_to_storage_form, m)?)?;
+    m.add_function(wrap_pyfunction!(batch_to_match_form, m)?)?;
+    m.add_function(wrap_pyfunction!(batch_to_ascii_form, m)?)?;
     Ok(())
 }
 
@@ -56,4 +62,40 @@ fn split_artist_name(name: &str) -> Option<Vec<String>> {
 #[pyfunction]
 fn split_artist_name_contextual(name: &str, known_artists: HashSet<String>) -> Option<Vec<String>> {
     wxyc_etl::text::split_artist_name_contextual(name, &known_artists)
+}
+
+/// WX-2 storage form: mojibake fix + NFC + trim.
+#[pyfunction]
+fn to_storage_form(s: &str) -> String {
+    wxyc_etl::text::to_storage_form(s)
+}
+
+/// WX-2 match form: NFKC + lowercase + selective combining-strip + folds + Cf-strip.
+#[pyfunction]
+fn to_match_form(s: &str) -> String {
+    wxyc_etl::text::to_match_form(s)
+}
+
+/// WX-2 ASCII form: match form + emoji-strip + Ё override + deunicode + ASCII-only.
+#[pyfunction]
+fn to_ascii_form(s: &str) -> String {
+    wxyc_etl::text::to_ascii_form(s)
+}
+
+/// Apply [`to_storage_form`] to each input in one cross-FFI call.
+#[pyfunction]
+fn batch_to_storage_form(inputs: Vec<String>) -> Vec<String> {
+    wxyc_etl::text::batch_to_storage_form(&inputs)
+}
+
+/// Apply [`to_match_form`] to each input in one cross-FFI call.
+#[pyfunction]
+fn batch_to_match_form(inputs: Vec<String>) -> Vec<String> {
+    wxyc_etl::text::batch_to_match_form(&inputs)
+}
+
+/// Apply [`to_ascii_form`] to each input in one cross-FFI call.
+#[pyfunction]
+fn batch_to_ascii_form(inputs: Vec<String>) -> Vec<String> {
+    wxyc_etl::text::batch_to_ascii_form(&inputs)
 }

--- a/wxyc-etl-python/tests/test_forms.py
+++ b/wxyc-etl-python/tests/test_forms.py
@@ -1,0 +1,100 @@
+"""WX-2.2.4 Python parity tests for the WX-2 Normalizer Charter forms.
+
+For each WX-1 charset-torture corpus entry that defines an
+`expected_storage_form` / `expected_match_form` / `expected_ascii_form`,
+assert that the PyO3 binding returns the same string as the Rust
+implementation (which is covered by `wxyc-etl/tests/forms_*.rs`).
+
+This is the cross-FFI parity contract called out in WX-2.2.4: the same
+input must produce the same output regardless of which language calls
+the function.
+
+Also covers the `batch_to_*_form` variants — the batched binding must
+return the same list as `[to_*_form(s) for s in inputs]`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from wxyc_etl import text
+
+_CORPUS_PATH = (
+    Path(__file__).resolve().parent.parent.parent / "tests" / "fixtures" / "charset-torture.json"
+)
+
+
+def _load_corpus():
+    return json.loads(_CORPUS_PATH.read_text(encoding="utf-8"))
+
+
+def _entries_with(field: str):
+    """Yield (category, entry) for every corpus entry where `field` is non-null."""
+    for category, entries in _load_corpus()["categories"].items():
+        for entry in entries:
+            if entry.get(field) is not None:
+                yield category, entry
+
+
+def _entry_id(pair) -> str:
+    category, entry = pair
+    return f"{category}:{entry['input'][:24]}"
+
+
+STORAGE_ENTRIES = list(_entries_with("expected_storage_form"))
+MATCH_ENTRIES = list(_entries_with("expected_match_form"))
+ASCII_ENTRIES = list(_entries_with("expected_ascii_form"))
+
+
+@pytest.mark.parametrize("pair", STORAGE_ENTRIES, ids=_entry_id)
+def test_to_storage_form_matches_corpus(pair) -> None:
+    _, entry = pair
+    assert text.to_storage_form(entry["input"]) == entry["expected_storage_form"], entry["notes"]
+
+
+@pytest.mark.parametrize("pair", MATCH_ENTRIES, ids=_entry_id)
+def test_to_match_form_matches_corpus(pair) -> None:
+    _, entry = pair
+    assert text.to_match_form(entry["input"]) == entry["expected_match_form"], entry["notes"]
+
+
+@pytest.mark.parametrize("pair", ASCII_ENTRIES, ids=_entry_id)
+def test_to_ascii_form_matches_corpus(pair) -> None:
+    _, entry = pair
+    assert text.to_ascii_form(entry["input"]) == entry["expected_ascii_form"], entry["notes"]
+
+
+# --- batch variants ---
+
+
+def _all_inputs() -> list[str]:
+    return [entry["input"] for _, entries in _load_corpus()["categories"].items() for entry in entries]
+
+
+def test_batch_to_storage_form_matches_singles() -> None:
+    inputs = _all_inputs()
+    assert text.batch_to_storage_form(inputs) == [text.to_storage_form(s) for s in inputs]
+
+
+def test_batch_to_match_form_matches_singles() -> None:
+    inputs = _all_inputs()
+    assert text.batch_to_match_form(inputs) == [text.to_match_form(s) for s in inputs]
+
+
+def test_batch_to_ascii_form_matches_singles() -> None:
+    inputs = _all_inputs()
+    assert text.batch_to_ascii_form(inputs) == [text.to_ascii_form(s) for s in inputs]
+
+
+def test_batch_to_storage_form_empty() -> None:
+    assert text.batch_to_storage_form([]) == []
+
+
+def test_batch_to_match_form_empty() -> None:
+    assert text.batch_to_match_form([]) == []
+
+
+def test_batch_to_ascii_form_empty() -> None:
+    assert text.batch_to_ascii_form([]) == []

--- a/wxyc-etl/src/text/batch.rs
+++ b/wxyc-etl/src/text/batch.rs
@@ -4,11 +4,27 @@
 //! avoiding per-item Python/Rust boundary crossings.
 
 use super::filter::ArtistFilter;
+use super::forms::{to_ascii_form, to_match_form, to_storage_form};
 use super::normalize::normalize_artist_name;
 
 /// Normalize a batch of artist names in one call.
 pub fn batch_normalize(names: &[String]) -> Vec<String> {
     names.iter().map(|n| normalize_artist_name(n)).collect()
+}
+
+/// Apply [`to_storage_form`] to each input in one call.
+pub fn batch_to_storage_form(inputs: &[String]) -> Vec<String> {
+    inputs.iter().map(|s| to_storage_form(s)).collect()
+}
+
+/// Apply [`to_match_form`] to each input in one call.
+pub fn batch_to_match_form(inputs: &[String]) -> Vec<String> {
+    inputs.iter().map(|s| to_match_form(s)).collect()
+}
+
+/// Apply [`to_ascii_form`] to each input in one call.
+pub fn batch_to_ascii_form(inputs: &[String]) -> Vec<String> {
+    inputs.iter().map(|s| to_ascii_form(s)).collect()
 }
 
 /// Normalize and check membership for a batch of names.
@@ -63,6 +79,35 @@ mod tests {
             batch_filter(&names, &filter),
             vec![true, false, true, false]
         );
+    }
+
+    #[test]
+    fn test_batch_to_storage_form_matches_singles() {
+        let inputs: Vec<String> = vec!["Stereolab".into(), "  Caf\u{00e9}  ".into()];
+        let expected: Vec<String> = inputs.iter().map(|s| to_storage_form(s)).collect();
+        assert_eq!(batch_to_storage_form(&inputs), expected);
+    }
+
+    #[test]
+    fn test_batch_to_match_form_matches_singles() {
+        let inputs: Vec<String> = vec!["STEREOLAB".into(), "Nil\u{00fc}fer Yanya".into()];
+        let expected: Vec<String> = inputs.iter().map(|s| to_match_form(s)).collect();
+        assert_eq!(batch_to_match_form(&inputs), expected);
+    }
+
+    #[test]
+    fn test_batch_to_ascii_form_matches_singles() {
+        let inputs: Vec<String> = vec!["\u{03a3}tella".into(), "Stereolab \u{1f3b8}".into()];
+        let expected: Vec<String> = inputs.iter().map(|s| to_ascii_form(s)).collect();
+        assert_eq!(batch_to_ascii_form(&inputs), expected);
+    }
+
+    #[test]
+    fn test_batch_form_helpers_empty() {
+        let names: Vec<String> = vec![];
+        assert!(batch_to_storage_form(&names).is_empty());
+        assert!(batch_to_match_form(&names).is_empty());
+        assert!(batch_to_ascii_form(&names).is_empty());
     }
 
     #[test]

--- a/wxyc-etl/src/text/mod.rs
+++ b/wxyc-etl/src/text/mod.rs
@@ -19,7 +19,9 @@ pub mod normalize;
 pub mod split;
 
 // Convenience re-exports for the most common entry points.
-pub use batch::{batch_filter, batch_normalize};
+pub use batch::{
+    batch_filter, batch_normalize, batch_to_ascii_form, batch_to_match_form, batch_to_storage_form,
+};
 pub use compilation::{is_compilation_artist, COMPILATION_KEYWORDS};
 pub use filter::{ArtistFilter, TitleFilter};
 pub use forms::{to_ascii_form, to_match_form, to_storage_form};


### PR DESCRIPTION
Closes #85.

## What

Expose the three WX-2 Normalizer Charter forms via PyO3 in `wxyc_etl.text`:

- `to_storage_form(s: str) -> str`
- `to_match_form(s: str) -> str`
- `to_ascii_form(s: str) -> str`
- `batch_to_storage_form(names: list[str]) -> list[str]`
- `batch_to_match_form(names: list[str]) -> list[str]`
- `batch_to_ascii_form(names: list[str]) -> list[str]`

The batch helpers live in `src/text/batch.rs` alongside the existing `batch_normalize`. Each one is a one-line `iter().map(|s| to_X_form(s)).collect()`, mirroring the `batch_normalize` precedent so semantic-index and discogs-etl can amortize the FFI boundary over thousands of artists.

## Tests

`wxyc-etl-python/tests/test_forms.py` drives every WX-1 charset-torture corpus entry that defines an `expected_storage_form` / `expected_match_form` / `expected_ascii_form` through the corresponding Python binding and asserts it matches the expected output. This is the cross-FFI parity contract: same input → same output regardless of which language calls the function.

It also asserts `batch_to_*_form(inputs) == [to_*_form(s) for s in inputs]` over the entire corpus, and that empty-input batches return empty lists.

Rust-side: 4 new `text::batch` unit tests exercise the batch wrappers (singles parity + empty-input).

## Verification

- `cargo test --workspace` — all 481 tests pass
- `cargo clippy --workspace --all-targets` (with the CI's `-A` allow-list) — clean
- `cargo fmt --check` — clean
- `maturin develop --release && pytest wxyc-etl-python/tests/` — 370 passed, 1 skipped, 3 deselected (102 of those are the new parity matrix)