### PR TITLE
release: bump workspace to 0.2.0 (WX-2.2.6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3133,7 +3133,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wxyc-etl"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "wxyc-etl-python"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,6 @@ members = ["wxyc-etl", "wxyc-etl-python"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Closes #87.

## What

Bumps the workspace version from `0.1.0` → `0.2.0` (minor: adds public API, deprecates legacy). The bump covers both `wxyc-etl` (Cargo crate) and `wxyc-etl-python` (PyO3 wheel) since they share \`version.workspace = true\`.

After merge, tagging \`v0.2.0\` on \`main\` triggers \`.github/workflows/release.yml\`, which:

- \`cargo publish -p wxyc-etl\` → crates.io (uses \`CRATES_IO_TOKEN\`)
- \`maturin build --release\` for x86_64-linux + aarch64-linux + aarch64-darwin → wheels
- \`maturin sdist\` → source dist
- \`maturin upload --skip-existing dist/*\` → PyPI (uses \`PYPI_API_TOKEN\`)

## Sanity check

Built the wheel locally and pip-installed into a throwaway venv. Verified:

\`\`\`
to_storage_form('Στella')  -> 'Στella'
to_match_form('Στella')    -> 'στella'
to_ascii_form('Στella')    -> 'stella'
batch_to_match_form([3])   -> ['stereolab', 'nilufer yanya', 'csillagrablok']

# legacy still works AND fires DeprecationWarning:
normalize_artist_name('Stereolab') -> 'stereolab'
DeprecationWarning: wxyc_etl.text.normalize_artist_name is deprecated;
  use to_match_form instead. See plans/mojibake-prevention/2-normalizer-charter.md
  for migration guidance.
\`\`\`

## Release notes (for tag annotation)

**0.2.0** adds the WX-2 Normalizer Charter API in \`wxyc_etl::text\`:

- \`to_storage_form\`: mojibake fix + NFC + trim. Idempotent.
- \`to_match_form\`: NFKC + lowercase + selective combining-strip + folds + Cf-strip.
- \`to_ascii_form\`: match form + emoji-strip + Ё override + deunicode + ASCII-only.
- Batch variants (\`batch_to_*_form\`) for amortizing per-call overhead in tight loops.
- Six matching PyO3 bindings in \`wxyc_etl.text\`.

The legacy normalizers (\`normalize_artist_name\`, \`strip_diacritics\`, \`normalize_title\`, \`batch_normalize\`) are marked \`#[deprecated]\` (Rust) and emit \`DeprecationWarning\` (Python). They still work; M3 per-repo migration retires each call site.

Once this PR merges, M2 of the WX-2 Normalizer Charter (docs#16) is complete and the M3 per-repo migration tickets (WX-2.3.1 through WX-2.3.6) become unblocked.