### PR TITLE
release: bump workspace to 0.2.1 with Optional[str] charter wrappers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3133,7 +3133,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wxyc-etl"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "wxyc-etl-python"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,6 @@ members = ["wxyc-etl", "wxyc-etl-python"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"

--- a/wxyc-etl-python/src/text.rs
+++ b/wxyc-etl-python/src/text.rs
@@ -90,21 +90,30 @@ fn split_artist_name_contextual(name: &str, known_artists: HashSet<String>) -> O
 }
 
 /// WX-2 storage form: mojibake fix + NFC + trim.
+///
+/// Accepts None (returns "") so Python callers don't need to guard NULL values
+/// from DB columns or optional API fields.
 #[pyfunction]
-fn to_storage_form(s: &str) -> String {
-    wxyc_etl::text::to_storage_form(s)
+fn to_storage_form(s: Option<&str>) -> String {
+    s.map(wxyc_etl::text::to_storage_form).unwrap_or_default()
 }
 
 /// WX-2 match form: NFKC + lowercase + selective combining-strip + folds + Cf-strip.
+///
+/// Accepts None (returns "") so Python callers don't need to guard NULL values
+/// from DB columns or optional API fields.
 #[pyfunction]
-fn to_match_form(s: &str) -> String {
-    wxyc_etl::text::to_match_form(s)
+fn to_match_form(s: Option<&str>) -> String {
+    s.map(wxyc_etl::text::to_match_form).unwrap_or_default()
 }
 
 /// WX-2 ASCII form: match form + emoji-strip + Ё override + deunicode + ASCII-only.
+///
+/// Accepts None (returns "") so Python callers don't need to guard NULL values
+/// from DB columns or optional API fields.
 #[pyfunction]
-fn to_ascii_form(s: &str) -> String {
-    wxyc_etl::text::to_ascii_form(s)
+fn to_ascii_form(s: Option<&str>) -> String {
+    s.map(wxyc_etl::text::to_ascii_form).unwrap_or_default()
 }
 
 /// Apply [`to_storage_form`] to each input in one cross-FFI call.

--- a/wxyc-etl-python/tests/test_forms_none.py
+++ b/wxyc-etl-python/tests/test_forms_none.py
@@ -1,0 +1,33 @@
+"""WX-2.2.4-followup: charter-form PyO3 wrappers must accept None.
+
+The legacy `wxyc_etl.text.normalize_artist_name(None) -> ""` contract is a
+load-bearing ergonomic — Python consumers commonly call the normalizer on a
+DB column that may be NULL. The first cut of the WX-2 charter (0.2.0) made
+`to_storage_form` / `to_match_form` / `to_ascii_form` raise `TypeError` on
+None, forcing every caller to add `name or ""` guards. This test pins the
+0.2.1 fix: same Optional[str] -> "" contract as the legacy.
+"""
+
+from __future__ import annotations
+
+import pytest
+from wxyc_etl import text
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [text.to_storage_form, text.to_match_form, text.to_ascii_form],
+    ids=["to_storage_form", "to_match_form", "to_ascii_form"],
+)
+def test_charter_forms_accept_none(fn) -> None:
+    assert fn(None) == ""
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [text.to_storage_form, text.to_match_form, text.to_ascii_form],
+    ids=["to_storage_form", "to_match_form", "to_ascii_form"],
+)
+def test_charter_forms_still_accept_str(fn) -> None:
+    """Sanity: the None-overload didn't break the str path."""
+    assert fn("Stereolab") != ""


### PR DESCRIPTION
## What

Restores the legacy \`Optional[str] -> ""\` contract on the WX-2 charter PyO3 wrappers. In 0.2.0, calling \`to_storage_form(None)\` / \`to_match_form(None)\` / \`to_ascii_form(None)\` raised \`TypeError\`; the legacy \`normalize_artist_name(None)\` had returned \`""\`. This forced every Python migrator to add \`name or ""\` guards.

The fix is one signature change per wrapper: \`fn to_X_form(s: &str)\` → \`fn to_X_form(s: Option<&str>)\` with \`.map(...).unwrap_or_default()\`. The Rust public API is unchanged — only the PyO3 boundary widens.

Batch variants (\`batch_to_*_form\`) keep their \`Vec<String>\` signature; lists with mixed-None elements aren't a real use case.

## Why

Three independent M3 migration agents (LML, semantic-index, discogs-etl PRs) surfaced and worked around this divergence. Captured in the WX-2 plan's "Cross-cutting findings from M3 implementation" section.

## Tests

\`tests/test_forms_none.py\` (6 cases): every charter form accepts \`None -> ""\` and continues to accept \`str -> non-empty\`. Full suite: 380 Python + 425 Rust tests pass.

## Migration impact

Once 0.2.1 is published and consumers bump the dep, the per-callsite \`name or ""\` guards added in M3 PRs become redundant. Cleanup is a follow-up; not strictly required (the guards continue to work).

## Release

After merge, tag \`v0.2.1\` to fire the release workflow: crates.io + abi3 wheel for x86_64-linux, aarch64-linux, aarch64-darwin.