### PR TITLE
text(identity): opt-in variants + 252-row parity matrix (E3 step 4 PR-B)

### DIFF
--- a/wxyc-etl-python/src/text.rs
+++ b/wxyc-etl-python/src/text.rs
@@ -15,6 +15,15 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(to_match_form, m)?)?;
     m.add_function(wrap_pyfunction!(to_ascii_form, m)?)?;
     m.add_function(wrap_pyfunction!(to_identity_match_form, m)?)?;
+    m.add_function(wrap_pyfunction!(to_identity_match_form_title, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        to_identity_match_form_with_punctuation,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        to_identity_match_form_with_disambiguator_strip,
+        m
+    )?)?;
     m.add_function(wrap_pyfunction!(batch_to_storage_form, m)?)?;
     m.add_function(wrap_pyfunction!(batch_to_match_form, m)?)?;
     m.add_function(wrap_pyfunction!(batch_to_ascii_form, m)?)?;
@@ -130,6 +139,37 @@ fn to_ascii_form(s: Option<&str>) -> String {
 #[pyfunction]
 fn to_identity_match_form(s: Option<&str>) -> String {
     s.map(wxyc_etl::text::to_identity_match_form)
+        .unwrap_or_default()
+}
+
+/// Title counterpart to `to_identity_match_form`. Use for cross-cache title
+/// identity matching; never strips trailing `/N` (titles use `Side A/2`-style
+/// disambiguators meaningfully).
+#[pyfunction]
+fn to_identity_match_form_title(s: Option<&str>) -> String {
+    s.map(wxyc_etl::text::to_identity_match_form_title)
+        .unwrap_or_default()
+}
+
+/// `to_identity_match_form` + plan §3.3.2 step 6: collapse runs of
+/// punctuation/symbol characters to a single ASCII space.
+///
+/// Opt-in: ships locked-on only if the regression report (plan §3.3.4) shows
+/// per-step shift ≤2%; otherwise stays opt-in.
+#[pyfunction]
+fn to_identity_match_form_with_punctuation(s: Option<&str>) -> String {
+    s.map(wxyc_etl::text::to_identity_match_form_with_punctuation)
+        .unwrap_or_default()
+}
+
+/// `to_identity_match_form` + plan §3.3.2 step 8: strip a trailing
+/// `\s*/\d+` Discogs artist-disambiguator suffix.
+///
+/// **Artists only.** Titles use `to_identity_match_form_title`, which does
+/// not strip `/N` (track-side disambiguators like `Side A/2` are meaningful).
+#[pyfunction]
+fn to_identity_match_form_with_disambiguator_strip(s: Option<&str>) -> String {
+    s.map(wxyc_etl::text::to_identity_match_form_with_disambiguator_strip)
         .unwrap_or_default()
 }
 

--- a/wxyc-etl-python/tests/test_forms_none.py
+++ b/wxyc-etl-python/tests/test_forms_none.py
@@ -6,6 +6,8 @@ DB column that may be NULL. The first cut of the WX-2 charter (0.2.0) made
 `to_storage_form` / `to_match_form` / `to_ascii_form` raise `TypeError` on
 None, forcing every caller to add `name or ""` guards. This test pins the
 0.2.1 fix: same Optional[str] -> "" contract as the legacy.
+
+Extended in E3 step 4 to cover the four cross-cache-identity entry points.
 """
 
 from __future__ import annotations
@@ -14,20 +16,32 @@ import pytest
 from wxyc_etl import text
 
 
-@pytest.mark.parametrize(
-    "fn",
-    [text.to_storage_form, text.to_match_form, text.to_ascii_form, text.to_identity_match_form],
-    ids=["to_storage_form", "to_match_form", "to_ascii_form", "to_identity_match_form"],
-)
+_FORMS = [
+    text.to_storage_form,
+    text.to_match_form,
+    text.to_ascii_form,
+    text.to_identity_match_form,
+    text.to_identity_match_form_title,
+    text.to_identity_match_form_with_punctuation,
+    text.to_identity_match_form_with_disambiguator_strip,
+]
+_IDS = [
+    "to_storage_form",
+    "to_match_form",
+    "to_ascii_form",
+    "to_identity_match_form",
+    "to_identity_match_form_title",
+    "to_identity_match_form_with_punctuation",
+    "to_identity_match_form_with_disambiguator_strip",
+]
+
+
+@pytest.mark.parametrize("fn", _FORMS, ids=_IDS)
 def test_charter_forms_accept_none(fn) -> None:
     assert fn(None) == ""
 
 
-@pytest.mark.parametrize(
-    "fn",
-    [text.to_storage_form, text.to_match_form, text.to_ascii_form, text.to_identity_match_form],
-    ids=["to_storage_form", "to_match_form", "to_ascii_form", "to_identity_match_form"],
-)
+@pytest.mark.parametrize("fn", _FORMS, ids=_IDS)
 def test_charter_forms_still_accept_str(fn) -> None:
     """Sanity: the None-overload didn't break the str path."""
     assert fn("Stereolab") != ""

--- a/wxyc-etl-python/tests/test_identity.py
+++ b/wxyc-etl-python/tests/test_identity.py
@@ -1,8 +1,11 @@
 """PyO3 parity for the cross-cache-identity layered normalizer.
 
-Locks the Python binding against the Rust implementation's behavior. Cases
-mirror `wxyc-etl/src/text/identity.rs`'s unit tests; the full parity matrix
-ships in a follow-up PR (epic #99).
+Locks the Python binding against the Rust implementation's behavior. The
+authoritative parity matrix lives at
+`wxyc-etl/tests/fixtures/identity_normalization_cases.csv` and is exercised
+by the Rust integration test `tests/identity_normalization_parity.rs`. The
+cases below are a Python-side smoke test that the FFI binding produces the
+same results as the Rust unit tests.
 
 Spec: `docs/normalization.md`.
 """
@@ -56,3 +59,55 @@ def test_identity_match_form_sigma_collision() -> None:
     final_form = "Στελλάς"
     medial_form = "Στελλάσ"
     assert text.to_identity_match_form(final_form) == text.to_identity_match_form(medial_form)
+
+
+# --- title variant: same as base today ---
+
+
+@pytest.mark.parametrize(
+    "input_str",
+    ["Stereolab", "The Sun Also Rises", "Foo (Live)", "Bar, The", ""],
+)
+def test_title_variant_matches_base(input_str: str) -> None:
+    assert text.to_identity_match_form_title(input_str) == text.to_identity_match_form(input_str)
+
+
+# --- step 6: punctuation collapse ---
+
+
+@pytest.mark.parametrize(
+    "input_str, expected",
+    [
+        ("M.I.A.", "m i a"),
+        ("R.E.M.", "r e m"),
+        ("Godspeed You! Black Emperor", "godspeed you black emperor"),
+        ("!!!", ""),
+        ("+/-", ""),
+        ("10,000 Maniacs", "10 000 maniacs"),
+        ("Foo!Bar (Live)", "foo bar"),
+        ("The M.I.A.", "m i a"),
+        ("Στελλάς", "στελλασ"),
+        ("", ""),
+    ],
+)
+def test_with_punctuation(input_str: str, expected: str) -> None:
+    assert text.to_identity_match_form_with_punctuation(input_str) == expected
+
+
+# --- step 8: trailing /N disambiguator ---
+
+
+@pytest.mark.parametrize(
+    "input_str, expected",
+    [
+        ("John Smith /1", "john smith"),
+        ("Various /17", "various"),
+        ("Track 1/12", "track 1/12"),
+        ("Side A/B", "side a/b"),
+        ("The John Smith /3 (1995)", "john smith"),
+        ("Stereolab", "stereolab"),
+        ("", ""),
+    ],
+)
+def test_with_disambiguator_strip(input_str: str, expected: str) -> None:
+    assert text.to_identity_match_form_with_disambiguator_strip(input_str) == expected

--- a/wxyc-etl/src/text/identity.rs
+++ b/wxyc-etl/src/text/identity.rs
@@ -10,13 +10,25 @@
 //! parens and leading articles that `to_match_form` preserves for FTS5 /
 //! prefix-lookup users.
 //!
-//! This module ships the locked-on baseline (steps 4 + 5 from plan §3.3.2).
-//! The opt-in step-6 (punctuation) and step-8 (`/N` disambiguator) variants
-//! and the full parity matrix ship in a follow-up PR; the regression-report
-//! harness ships in a third.
+//! Public surface:
 //!
-//! Locked-on means: the regression-report `D` per-step shift on these rules
-//! triggers algorithm refinement, *not* opt-out (plan §3.3.4).
+//! - [`to_identity_match_form`] — locked-on baseline (steps 4 + 5).
+//! - [`to_identity_match_form_title`] — title-side counterpart; same as base
+//!   today. Distinct symbol so callers explicitly opt out of the artist-only
+//!   `/N` disambiguator strip; future step-6 promotion stays type-safe.
+//! - [`to_identity_match_form_with_punctuation`] — opt-in: adds step 6
+//!   (punctuation collapse). Ships if the regression report's per-step shift
+//!   on this rule is ≤2%; otherwise stays opt-in indefinitely (plan §3.3.4).
+//! - [`to_identity_match_form_with_disambiguator_strip`] — opt-in: adds
+//!   step 8 (trailing `/N` disambiguator strip). Artists only; titles use
+//!   `_title` since `Side A/2` is meaningful disambiguation.
+//!
+//! Locked-on means: the regression-report `D` per-step shift on steps 4 + 5
+//! triggers algorithm refinement, *not* opt-out (plan §3.3.4). Opt-in steps
+//! 6 and 8 are exposed under separate function names so callers (and the
+//! eventual Postgres analog) audit the choice at the call site.
+use unicode_categories::UnicodeCategories;
+
 use super::forms::{collapse_and_trim_ascii_space, to_match_form};
 
 /// Identity-match form. The canonical entry point for cross-cache identity
@@ -51,10 +63,122 @@ use super::forms::{collapse_and_trim_ascii_space, to_match_form};
 ///
 /// Idempotent on every input: `to_identity_match_form(to_identity_match_form(s)) == to_identity_match_form(s)`.
 pub fn to_identity_match_form(s: &str) -> String {
+    identity_baseline(s)
+}
+
+/// Title counterpart to [`to_identity_match_form`]. Currently identical to the
+/// base function — exists as a separate public symbol so:
+/// - Callers explicitly type-distinguish artist vs title at the call site,
+///   making it impossible to accidentally hand a title to
+///   `to_identity_match_form_with_disambiguator_strip` (which would strip
+///   `Side A/2` style track-side disambiguators).
+/// - When step 6 (punctuation collapse) eventually promotes to locked-on, the
+///   title surface remains stable for callers that already typed against this
+///   symbol.
+///
+/// Idempotent.
+pub fn to_identity_match_form_title(s: &str) -> String {
+    identity_baseline(s)
+}
+
+/// [`to_identity_match_form`] + plan §3.3.2 step 6: replace each run of
+/// punctuation/symbol characters (anything that is not a Unicode letter,
+/// number, or whitespace) with a single ASCII space, then re-collapse and
+/// re-trim. Examples:
+///
+/// - `Godspeed You! Black Emperor` → `godspeed you black emperor`
+/// - `M.I.A.` → `m i a`
+/// - `+/-` → ``  (entirely punctuation; reduces to empty — caller's fallback)
+///
+/// Opt-in: gated behind this separately-named function until the regression
+/// report shows the per-step shift on real cache data is ≤2%, at which point
+/// the project lead may promote it to locked-on. Until then, callers that
+/// want this behavior have to opt in explicitly.
+///
+/// Idempotent.
+pub fn to_identity_match_form_with_punctuation(s: &str) -> String {
+    let m = to_match_form(s);
+    let m = strip_trailing_parens(&m);
+    let m = drop_articles(m);
+    let m = collapse_punctuation_to_space(&m);
+    collapse_and_trim_ascii_space(&m)
+}
+
+/// [`to_identity_match_form`] + plan §3.3.2 step 8: strip a trailing
+/// `\s*/\d+` (Discogs artist-disambiguator suffix) at end-of-string.
+/// Examples:
+///
+/// - `John Smith /1` → `john smith`
+/// - `Various /17` → `various`
+/// - `Track 1/12` (no leading whitespace before `/`) → `track 1/12`
+///
+/// **Artists only.** Discogs uses `/N` to disambiguate same-name artists
+/// (`John Smith /1` vs `John Smith /2`). Titles use `/N` for legitimate
+/// in-title disambiguation (`Side A/2`, `Track 1/12`). Use
+/// [`to_identity_match_form_title`] for title-side identity matching.
+///
+/// Idempotent.
+pub fn to_identity_match_form_with_disambiguator_strip(s: &str) -> String {
+    let baseline = identity_baseline(s);
+    strip_trailing_disambiguator(&baseline)
+}
+
+fn identity_baseline(s: &str) -> String {
     let m = to_match_form(s);
     let m = strip_trailing_parens(&m);
     let m = drop_articles(m);
     collapse_and_trim_ascii_space(&m)
+}
+
+/// Replace each run of one or more non-letter, non-number, non-whitespace
+/// codepoints with a single ASCII space. Letter/number recognition is
+/// Unicode-property-aware: Greek `α`, Cyrillic `я`, Han `細` all qualify
+/// as letters. The output may have leading/trailing/runs-of space; the
+/// caller is expected to follow with [`collapse_and_trim_ascii_space`].
+fn collapse_punctuation_to_space(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_was_replacement = false;
+    for c in s.chars() {
+        if c.is_letter() || c.is_number() || c.is_whitespace() {
+            out.push(c);
+            prev_was_replacement = false;
+        } else if !prev_was_replacement {
+            out.push(' ');
+            prev_was_replacement = true;
+        }
+    }
+    out
+}
+
+/// Strip a trailing `\s+/\d+` group. The leading whitespace is **required**:
+/// `John Smith /1` strips, `Track 1/12` does not. The original spec's regex
+/// (`\s*/\d+$`) is zero-or-more whitespace, but the spec doc itself names
+/// `Track 1/12` as a step-8 negative (it survives because the `/` follows a
+/// digit with no space). Requiring `\s+` makes the in-the-wild Discogs
+/// convention (`Artist /N`, always with a space) match while preserving
+/// genuine in-string `X/Y` patterns.
+fn strip_trailing_disambiguator(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut end = bytes.len();
+    if end == 0 || !bytes[end - 1].is_ascii_digit() {
+        return s.to_string();
+    }
+    while end > 0 && bytes[end - 1].is_ascii_digit() {
+        end -= 1;
+    }
+    if end == 0 || bytes[end - 1] != b'/' {
+        return s.to_string();
+    }
+    let slash = end - 1;
+    let mut after_spaces = slash;
+    while after_spaces > 0 && bytes[after_spaces - 1] == b' ' {
+        after_spaces -= 1;
+    }
+    if after_spaces == slash {
+        // No whitespace before the slash — `Track 1/12` style. Preserve.
+        return s.to_string();
+    }
+    s[..after_spaces].to_string()
 }
 
 /// Strip a single trailing `(...)` or `[...]` group plus any preceding ASCII
@@ -338,6 +462,166 @@ mod tests {
                 to_identity_match_form(s),
                 "idempotence broken for {s:?}"
             );
+        }
+    }
+
+    // --- title variant: same as base today ---
+
+    #[test]
+    fn title_variant_matches_base() {
+        for s in [
+            "Stereolab",
+            "The Sun Also Rises",
+            "Foo (Live)",
+            "Bar, The",
+            "",
+        ] {
+            assert_eq!(
+                to_identity_match_form_title(s),
+                to_identity_match_form(s),
+                "title variant diverged from base for {s:?}"
+            );
+        }
+    }
+
+    // --- step 6: punctuation collapse (with_punctuation variant) ---
+
+    #[test]
+    fn punctuation_collapses_dots() {
+        assert_eq!(to_identity_match_form_with_punctuation("M.I.A."), "m i a");
+    }
+
+    #[test]
+    fn punctuation_collapses_excitement() {
+        assert_eq!(
+            to_identity_match_form_with_punctuation("Godspeed You! Black Emperor"),
+            "godspeed you black emperor"
+        );
+    }
+
+    #[test]
+    fn punctuation_collapses_run_of_punctuation_to_single_space() {
+        // Per spec: replace each run of punctuation chars with one ASCII space.
+        assert_eq!(to_identity_match_form_with_punctuation("!!!"), "");
+        assert_eq!(to_identity_match_form_with_punctuation("+/-"), "");
+        assert_eq!(to_identity_match_form_with_punctuation("R.E.M."), "r e m");
+    }
+
+    #[test]
+    fn punctuation_preserves_letters_and_numbers() {
+        assert_eq!(
+            to_identity_match_form_with_punctuation("10,000 Maniacs"),
+            "10 000 maniacs"
+        );
+    }
+
+    #[test]
+    fn punctuation_preserves_unicode_letters() {
+        // Greek/Cyrillic/Han letters survive the punctuation pass.
+        assert_eq!(
+            to_identity_match_form_with_punctuation("Στελλάς"),
+            "στελλασ"
+        );
+    }
+
+    #[test]
+    fn punctuation_runs_after_paren_strip() {
+        // Trailing-paren strip happens first, so `(Live)` is gone before step 6
+        // sees the input. The remaining punctuation is what gets collapsed.
+        assert_eq!(
+            to_identity_match_form_with_punctuation("Foo!Bar (Live)"),
+            "foo bar"
+        );
+    }
+
+    #[test]
+    fn punctuation_after_article_drop() {
+        assert_eq!(
+            to_identity_match_form_with_punctuation("The M.I.A."),
+            "m i a"
+        );
+    }
+
+    #[test]
+    fn punctuation_idempotent() {
+        for s in [
+            "M.I.A.",
+            "10,000 Maniacs",
+            "Godspeed You! Black Emperor",
+            "Foo!Bar (Live)",
+            "",
+        ] {
+            let once = to_identity_match_form_with_punctuation(s);
+            let twice = to_identity_match_form_with_punctuation(&once);
+            assert_eq!(once, twice, "idempotence broken for {s:?}");
+        }
+    }
+
+    // --- step 8: trailing /N disambiguator strip ---
+
+    #[test]
+    fn disambiguator_strips_one_digit() {
+        assert_eq!(
+            to_identity_match_form_with_disambiguator_strip("John Smith /1"),
+            "john smith"
+        );
+    }
+
+    #[test]
+    fn disambiguator_strips_multi_digit() {
+        assert_eq!(
+            to_identity_match_form_with_disambiguator_strip("Various /17"),
+            "various"
+        );
+    }
+
+    #[test]
+    fn disambiguator_requires_leading_space_before_slash() {
+        // `Track 1/12` has no whitespace before `/`; preserved.
+        assert_eq!(
+            to_identity_match_form_with_disambiguator_strip("Track 1/12"),
+            "track 1/12"
+        );
+    }
+
+    #[test]
+    fn disambiguator_does_not_strip_trailing_letter() {
+        assert_eq!(
+            to_identity_match_form_with_disambiguator_strip("Side A/B"),
+            "side a/b"
+        );
+    }
+
+    #[test]
+    fn disambiguator_strips_after_paren_and_article_drops() {
+        // Pipeline order: to_match_form → parens → article → re-collapse → /N.
+        assert_eq!(
+            to_identity_match_form_with_disambiguator_strip("The John Smith /3 (1995)"),
+            "john smith"
+        );
+    }
+
+    #[test]
+    fn disambiguator_no_match_passes_through() {
+        assert_eq!(
+            to_identity_match_form_with_disambiguator_strip("Stereolab"),
+            "stereolab"
+        );
+    }
+
+    #[test]
+    fn disambiguator_idempotent() {
+        for s in [
+            "John Smith /1",
+            "Various /17",
+            "Track 1/12",
+            "The John Smith /3 (1995)",
+            "Stereolab",
+            "",
+        ] {
+            let once = to_identity_match_form_with_disambiguator_strip(s);
+            let twice = to_identity_match_form_with_disambiguator_strip(&once);
+            assert_eq!(once, twice, "idempotence broken for {s:?}");
         }
     }
 }

--- a/wxyc-etl/src/text/mod.rs
+++ b/wxyc-etl/src/text/mod.rs
@@ -24,7 +24,10 @@ pub use batch::{batch_filter, batch_to_ascii_form, batch_to_match_form, batch_to
 pub use compilation::{is_compilation_artist, COMPILATION_KEYWORDS};
 pub use filter::{ArtistFilter, TitleFilter};
 pub use forms::{to_ascii_form, to_match_form, to_storage_form};
-pub use identity::to_identity_match_form;
+pub use identity::{
+    to_identity_match_form, to_identity_match_form_title,
+    to_identity_match_form_with_disambiguator_strip, to_identity_match_form_with_punctuation,
+};
 pub use mojibake::fix_mojibake;
 pub use split::{split_artist_name, split_artist_name_contextual};
 

--- a/wxyc-etl/tests/fixtures/identity_normalization_cases.csv
+++ b/wxyc-etl/tests/fixtures/identity_normalization_cases.csv
@@ -1,0 +1,274 @@
+input,expected,variant,category,notes
+# Categorical parity matrix for plan §3.3.2 steps 4-6 + 8.
+# Variant column: which function to call.
+#   base     → to_identity_match_form
+#   title    → to_identity_match_form_title
+#   punct    → to_identity_match_form_with_punctuation
+#   disamb   → to_identity_match_form_with_disambiguator_strip
+# Category column: which §3.3.2 step or behavior is exercised. Empty notes
+# column is allowed; lowercase ASCII expected (to_match_form pre-pass).
+# Steps 1-3 + 7 coverage delegated to charset-torture.json (WX-1).
+
+# ===== trailing-parens-artist (50) =====
+Stereolab (Live),stereolab,base,trailing-parens-artist,
+Cat Power (Remastered),cat power,base,trailing-parens-artist,
+Animal Collective (Live at Lincoln Hall),animal collective,base,trailing-parens-artist,
+Beach House (Demo),beach house,base,trailing-parens-artist,
+Big Thief (Acoustic),big thief,base,trailing-parens-artist,
+Aphex Twin (1992),aphex twin,base,trailing-parens-artist,
+Autechre (Reissue),autechre,base,trailing-parens-artist,
+Boards of Canada (Original Mix),boards of canada,base,trailing-parens-artist,
+Broadcast (Live),broadcast,base,trailing-parens-artist,
+Brian Eno (Ambient),brian eno,base,trailing-parens-artist,
+Burial (12 Inch),burial,base,trailing-parens-artist,
+Cocteau Twins (1984),cocteau twins,base,trailing-parens-artist,
+Colin Stetson (Live),colin stetson,base,trailing-parens-artist,
+Damien Jurado (Demo),damien jurado,base,trailing-parens-artist,
+Deerhoof (Live in Tokyo),deerhoof,base,trailing-parens-artist,
+Elliott Smith (Posthumous),elliott smith,base,trailing-parens-artist,
+Father John Misty (Solo),father john misty,base,trailing-parens-artist,
+Flying Lotus (Brainfeeder),flying lotus,base,trailing-parens-artist,
+Four Tet (Remix),four tet,base,trailing-parens-artist,
+Gil Scott-Heron (Live),gil scott-heron,base,trailing-parens-artist,
+Hermanos Gutiérrez (En Vivo),hermanos gutierrez,base,trailing-parens-artist,
+Jessica Pratt (Live in LA),jessica pratt,base,trailing-parens-artist,
+Juana Molina (Acoustic),juana molina,base,trailing-parens-artist,
+Stereolab [Live],stereolab,base,trailing-parens-artist,square brackets
+Cat Power [Remastered],cat power,base,trailing-parens-artist,square brackets
+Animal Collective [Demos],animal collective,base,trailing-parens-artist,square brackets
+Beach House [Acoustic],beach house,base,trailing-parens-artist,square brackets
+Big Thief [Live],big thief,base,trailing-parens-artist,square brackets
+Aphex Twin [1992],aphex twin,base,trailing-parens-artist,square brackets
+Autechre [Bonus],autechre,base,trailing-parens-artist,square brackets
+Boards of Canada [Original Mix],boards of canada,base,trailing-parens-artist,square brackets
+Broadcast [Live],broadcast,base,trailing-parens-artist,square brackets
+Brian Eno [Ambient],brian eno,base,trailing-parens-artist,square brackets
+Stereolab  (Live),stereolab,base,trailing-parens-artist,doubled space before group → match-form collapses to single
+Cat Power   (1995),cat power,base,trailing-parens-artist,triple space before group
+Stereolab(),stereolab,base,trailing-parens-artist,no space before parens
+Cat Power(Live),cat power,base,trailing-parens-artist,no space before parens
+Aphex Twin (selected ambient works),aphex twin,base,trailing-parens-artist,multi-word inside parens
+Autechre (lp5),autechre,base,trailing-parens-artist,
+Beach House (b-sides and rarities),beach house,base,trailing-parens-artist,
+Big Thief (live at the brooklyn academy),big thief,base,trailing-parens-artist,
+Stereolab (mars audiac quintet),stereolab,base,trailing-parens-artist,
+Stereolab (Live (1999) Edition),stereolab,base,trailing-parens-artist,nested parens balanced
+Cat Power (Sun (Remastered)),cat power,base,trailing-parens-artist,nested parens balanced
+Beach House (Bloom (10th)),beach house,base,trailing-parens-artist,nested parens balanced
+Stereolab ((Live)),stereolab,base,trailing-parens-artist,double-open
+(Cat Power),(cat power),base,trailing-parens-artist,only-parens negative — preserved
+[Stereolab],[stereolab],base,trailing-parens-artist,only-brackets negative — preserved
+Autechre ),autechre ),base,trailing-parens-artist,unbalanced close — passes through
+Stereolab (Live (1999),stereolab (live,base,trailing-parens-artist,unbalanced inner-open: outer scan strips only the (1999)
+Broadcast (Live) [2003],broadcast (live),base,trailing-parens-artist,one pass — only outermost stripped
+
+# ===== trailing-parens-title (50) =====
+"What Time Is It, Mr. Fox? (Live)","what time is it, mr. fox?",title,trailing-parens-title,strip outer paren only — comma preserved
+Sugar Hill (Acoustic),sugar hill,title,trailing-parens-title,
+La Paradoja (Single Edit),la paradoja,title,trailing-parens-title,
+"Back, Baby (Demo)","back, baby",title,trailing-parens-title,comma in title preserved
+Call Your Name (Edits),call your name,title,trailing-parens-title,
+In a Sentimental Mood (Live),in a sentimental mood,title,trailing-parens-title,
+Aluminum Tunes (Vol 1),aluminum tunes,title,trailing-parens-title,
+DOGA (Album Version),doga,title,trailing-parens-title,
+On Your Own Love Again (Reissue),on your own love again,title,trailing-parens-title,
+Edits (Bonus),edits,title,trailing-parens-title,
+Wedding Song (Live),wedding song,title,trailing-parens-title,
+Saturday (Acoustic),saturday,title,trailing-parens-title,
+Blue Moon (1956),blue moon,title,trailing-parens-title,
+The Birthday Party (1973),birthday party,title,trailing-parens-title,title variant runs full baseline (paren strip + article drop)
+"Track 1, Side A (Live)","track 1, side a",title,trailing-parens-title,comma preserved
+Sugar Hill [Demo],sugar hill,title,trailing-parens-title,square
+La Paradoja [Reissue],la paradoja,title,trailing-parens-title,square
+"Back, Baby [Acoustic]","back, baby",title,trailing-parens-title,square + comma
+Call Your Name [Bonus],call your name,title,trailing-parens-title,square
+In a Sentimental Mood [Live 1962],in a sentimental mood,title,trailing-parens-title,square
+Sugar Hill (),sugar hill,title,trailing-parens-title,empty parens stripped
+Sugar Hill ( ),sugar hill,title,trailing-parens-title,whitespace-only inside parens
+DOGA   (Edit),doga,title,trailing-parens-title,multi-space before parens collapsed by match-form
+DOGA(Edit),doga,title,trailing-parens-title,no leading space
+Edits (Vol 1) [2025],edits (vol 1),title,trailing-parens-title,one-pass — outermost only
+Saturday (Take 1) (Take 2),saturday (take 1),title,trailing-parens-title,one-pass
+(Sugar Hill),(sugar hill),title,trailing-parens-title,only-parens preserved
+[Sugar Hill],[sugar hill],title,trailing-parens-title,only-brackets preserved
+Sugar Hill ),sugar hill ),title,trailing-parens-title,unbalanced close
+Sugar Hill (Live (1999) Edition),sugar hill,title,trailing-parens-title,nested
+Wedding Song (1971),wedding song,title,trailing-parens-title,
+Wedding Song [1971],wedding song,title,trailing-parens-title,
+Saturday Morning (Edit),saturday morning,title,trailing-parens-title,
+Blue (Live in Berlin),blue,title,trailing-parens-title,
+Blue [Live in Berlin],blue,title,trailing-parens-title,
+Suite for Solo Cello (Bach),suite for solo cello,title,trailing-parens-title,
+For Free (Joni Mitchell Cover),for free,title,trailing-parens-title,
+For Free [Joni Mitchell Cover],for free,title,trailing-parens-title,
+La Paradoja (Vol 2),la paradoja,title,trailing-parens-title,
+La Paradoja II (Live),la paradoja ii,title,trailing-parens-title,
+Edits (Compilation),edits,title,trailing-parens-title,
+Edits Vol. 2 (Mini),edits vol. 2,title,trailing-parens-title,
+Edits Vol. 2 [Mini],edits vol. 2,title,trailing-parens-title,
+First Light (Take 1),first light,title,trailing-parens-title,
+First Light [Take 1],first light,title,trailing-parens-title,
+First Light (Take 1) (Take 2),first light (take 1),title,trailing-parens-title,
+First Light [Take 1] [Take 2],first light [take 1],title,trailing-parens-title,
+The Cat in the Hat (Original),cat in the hat,title,trailing-parens-title,title runs full baseline — article dropped
+The Sun Also Rises (Edit),sun also rises,title,trailing-parens-title,title runs full baseline — article dropped
+The Goldberg Variations (Bach),goldberg variations,title,trailing-parens-title,title runs full baseline — article dropped
+
+# ===== leading-article (25) =====
+The Field,field,base,leading-article,canonical WXYC artist
+A Tribe Called Quest,tribe called quest,base,leading-article,canonical WXYC artist
+The Beatles,beatles,base,leading-article,classic example
+A Place to Bury Strangers,place to bury strangers,base,leading-article,
+An Albatross,albatross,base,leading-article,
+The Microphones,microphones,base,leading-article,
+A Silver Mt. Zion,silver mt. zion,base,leading-article,
+The The,the,base,leading-article,only first article dropped
+The Sun Also Rises,sun also rises,base,leading-article,
+The Field (Live),field,base,leading-article,article + paren strip composed
+A Tribe Called Quest (Demos),tribe called quest,base,leading-article,article + paren strip composed
+The Microphones [1999],microphones,base,leading-article,bracket variant
+"Field, The",field,base,leading-article,Discogs comma form
+"Tribe Called Quest, A",tribe called quest,base,leading-article,Discogs comma form
+"Albatross, An",albatross,base,leading-article,Discogs comma form
+"Microphones, The",microphones,base,leading-article,Discogs comma form
+"Sun Also Rises, The",sun also rises,base,leading-article,Discogs comma form
+"Field, The (1995)",field,base,leading-article,comma + paren strip composed
+"Tribe Called Quest, A [Demos]",tribe called quest,base,leading-article,comma + bracket strip composed
+Theater of Tragedy,theater of tragedy,base,leading-article,prefix substring negative
+Animal Collective,animal collective,base,leading-article,no article negative
+Andy Human and the Reptoids,andy human and the reptoids,base,leading-article,article in middle preserved
+"Beatles, the Best Of","beatles, the best of",base,leading-article,trailing comma not at end-of-string
+Aphex Twin,aphex twin,base,leading-article,no article negative
+"Stereolab, The",stereolab,base,leading-article,Discogs comma form
+
+# ===== punct (50) — to_identity_match_form_with_punctuation =====
+M.I.A.,m i a,punct,punct,classic dotted abbreviation
+R.E.M.,r e m,punct,punct,
+O.D.B.,o d b,punct,punct,
++/-,,punct,punct,reduces to empty
+!!!,,punct,punct,reduces to empty
+"10,000 Maniacs",10 000 maniacs,punct,punct,comma collapses
+Godspeed You! Black Emperor,godspeed you black emperor,punct,punct,
+Of Montreal,of montreal,punct,punct,no punctuation passthrough
+Sigur Rós,sigur ros,punct,punct,no punctuation passthrough
+Big Thief,big thief,punct,punct,
+Dam-Funk,dam funk,punct,punct,hyphen collapses
+Gil Scott-Heron,gil scott heron,punct,punct,hyphen collapses
+"Crosby, Stills & Nash",crosby stills nash,punct,punct,
+"Earth, Wind & Fire",earth wind fire,punct,punct,
+"Tyler, the Creator",tyler the creator,punct,punct,
+"Jay-Z",jay z,punct,punct,
+"Diiv",diiv,punct,punct,
+A.A. Bondy,a a bondy,punct,punct,
+A.S.A.P. Rocky,a s a p rocky,punct,punct,
+Cluster & Eno,cluster eno,punct,punct,ampersand collapses
+"Tortoise & Bonnie 'Prince' Billy",tortoise bonnie prince billy,punct,punct,straight quotes collapse
+Bonnie 'Prince' Billy,bonnie prince billy,punct,punct,
+"D'Angelo",d angelo,punct,punct,apostrophe collapses
+Don't Be a Stranger,don t be a stranger,punct,punct,apostrophe collapses
+Sun O))),sun o,punct,punct,reduces to letters only — paren strip first removes nothing because no balanced group
+Foo!Bar (Live),foo bar,punct,punct,paren strip then punct collapse
+Foo!Bar [Demo],foo bar,punct,punct,paren strip then punct collapse
+The M.I.A.,m i a,punct,punct,article drop then punct
+"M.I.A., The",m i a,punct,punct,Discogs comma + punct collapse
+Black Midi,black midi,punct,punct,no punctuation passthrough
+Mount Eerie,mount eerie,punct,punct,
+Aphex Twin,aphex twin,punct,punct,
+Stereolab,stereolab,punct,punct,
+Cat Power,cat power,punct,punct,
+Beach House,beach house,punct,punct,
+Big Thief,big thief,punct,punct,
+Animal Collective,animal collective,punct,punct,
+Boards of Canada,boards of canada,punct,punct,
+Brian Eno,brian eno,punct,punct,
+Broadcast,broadcast,punct,punct,
+Burial,burial,punct,punct,
+Cocteau Twins,cocteau twins,punct,punct,
+Colin Stetson,colin stetson,punct,punct,
+Csillagrablók,csillagrablok,punct,punct,Unicode letter survives
+Στελλάς,στελλασ,punct,punct,Greek letter survives
+Молчат Дома,молчат дома,punct,punct,Cyrillic letter survives
+細野晴臣,細野晴臣,punct,punct,Han letters survive
+Sigur Rós,sigur ros,punct,punct,
+Hermanos Gutiérrez,hermanos gutierrez,punct,punct,
+Aşıq Altay,asıq altay,punct,punct,Turkish dotless i survives
+
+# ===== disamb (50) — to_identity_match_form_with_disambiguator_strip =====
+John Smith /1,john smith,disamb,disamb,
+John Smith /2,john smith,disamb,disamb,
+Various /17,various,disamb,disamb,
+Stereolab /1,stereolab,disamb,disamb,
+Stereolab /17,stereolab,disamb,disamb,
+Cat Power /3,cat power,disamb,disamb,
+Big Thief /2,big thief,disamb,disamb,
+Beach House /1,beach house,disamb,disamb,
+Aphex Twin /1,aphex twin,disamb,disamb,
+Autechre /2,autechre,disamb,disamb,
+Boards of Canada /1,boards of canada,disamb,disamb,
+Broadcast /2,broadcast,disamb,disamb,
+Brian Eno /1,brian eno,disamb,disamb,
+Burial /1,burial,disamb,disamb,
+Cocteau Twins /1,cocteau twins,disamb,disamb,
+Colin Stetson /1,colin stetson,disamb,disamb,
+Damien Jurado /1,damien jurado,disamb,disamb,
+Deerhoof /1,deerhoof,disamb,disamb,
+Elliott Smith /1,elliott smith,disamb,disamb,
+Father John Misty /1,father john misty,disamb,disamb,
+Flying Lotus /1,flying lotus,disamb,disamb,
+Four Tet /1,four tet,disamb,disamb,
+Gil Scott-Heron /1,gil scott-heron,disamb,disamb,
+Hermanos Gutiérrez /1,hermanos gutierrez,disamb,disamb,
+Jessica Pratt /1,jessica pratt,disamb,disamb,
+Juana Molina /1,juana molina,disamb,disamb,
+The Beatles /1,beatles,disamb,disamb,article drop + disamb composed
+A Tribe Called Quest /1,tribe called quest,disamb,disamb,article + disamb composed
+"Beatles, The /1","beatles, the",disamb,disamb,Discogs comma form is masked by /1 in baseline; only /1 strips at the disamb step (comma form does not re-fire)
+The Field /2 (Live),field,disamb,disamb,article + paren + disamb composed
+The Microphones /3,microphones,disamb,disamb,
+Track 1/12,track 1/12,disamb,disamb,no whitespace before slash — preserved
+Side A/B,side a/b,disamb,disamb,trailing letter — preserved
+Track 1/12345,track 1/12345,disamb,disamb,no whitespace
+Section 4/5,section 4/5,disamb,disamb,no whitespace
+1/4,1/4,disamb,disamb,bare digits
+"Stereolab /17 (Live)",stereolab,disamb,disamb,paren first then disamb
+Cat Power /3 [Live],cat power,disamb,disamb,bracket then disamb
+"Cat Power /3 (Demo)",cat power,disamb,disamb,paren then disamb
+Stereolab,stereolab,disamb,disamb,no disambiguator passthrough
+Cat Power,cat power,disamb,disamb,no disambiguator passthrough
+Beach House,beach house,disamb,disamb,no disambiguator passthrough
+M /1,m,disamb,disamb,single-letter stem
+M.I.A. /1,m.i.a.,disamb,disamb,disamb strips trailing /N; dotted abbreviation survives because disamb does not punct-collapse
+"Stereolab /1, The",stereolab,disamb,disamb,trailing comma form before disamb digits — wait this has /1 first
+Various Artists /1,various artists,disamb,disamb,
+Various Artists /99,various artists,disamb,disamb,
+Compilation /1,compilation,disamb,disamb,
+Compilation /5,compilation,disamb,disamb,
+Various /999,various,disamb,disamb,three-digit
+Bach /1,bach,disamb,disamb,
+
+# ===== disamb-title-negative (25) — title variant must NOT strip /N =====
+Track 1/12,track 1/12,title,disamb-title-negative,
+Side A/B,side a/b,title,disamb-title-negative,
+Track 2/12,track 2/12,title,disamb-title-negative,
+Track 11/12,track 11/12,title,disamb-title-negative,
+Section 4/5,section 4/5,title,disamb-title-negative,
+1/4,1/4,title,disamb-title-negative,
+Wedding Song /1,wedding song /1,title,disamb-title-negative,title variant preserves /N
+Sugar Hill /2,sugar hill /2,title,disamb-title-negative,
+La Paradoja /3,la paradoja /3,title,disamb-title-negative,
+"Back, Baby /1","back, baby /1",title,disamb-title-negative,
+Call Your Name /4,call your name /4,title,disamb-title-negative,
+In a Sentimental Mood /1,in a sentimental mood /1,title,disamb-title-negative,
+Suite No. 1/2,suite no. 1/2,title,disamb-title-negative,no whitespace
+Side 1/2,side 1/2,title,disamb-title-negative,
+Movement 4/4,movement 4/4,title,disamb-title-negative,
+Variation 1/30,variation 1/30,title,disamb-title-negative,
+"Symphony No. 9, Mvmt. 4/4","symphony no. 9, mvmt. 4/4",title,disamb-title-negative,
+Bagatelle 11/11,bagatelle 11/11,title,disamb-title-negative,
+Etude 24/24,etude 24/24,title,disamb-title-negative,
+Prelude 1/24,prelude 1/24,title,disamb-title-negative,
+Concerto 5/6,concerto 5/6,title,disamb-title-negative,
+Mass 1/4,mass 1/4,title,disamb-title-negative,
+Volume 1/3,volume 1/3,title,disamb-title-negative,
+Disc 1/2,disc 1/2,title,disamb-title-negative,
+CD 1/2,cd 1/2,title,disamb-title-negative,

--- a/wxyc-etl/tests/identity_normalization_parity.rs
+++ b/wxyc-etl/tests/identity_normalization_parity.rs
@@ -1,0 +1,178 @@
+//! Parity matrix for the cross-cache-identity layered normalizer.
+//!
+//! Loads `tests/fixtures/identity_normalization_cases.csv` (see plan §3.3.3
+//! parity-test matrix) and asserts the four identity functions reproduce the
+//! pinned expected outputs row-by-row. The CSV is the locked spec for this
+//! layer; the Postgres analog (`wxyc_identity_match_artist`) targets the
+//! same outputs byte-for-byte.
+//!
+//! Format:
+//!   input,expected,variant,category,notes
+//!   variant ∈ {base, title, punct, disamb}
+//!
+//! Lines starting with `#` are comments. Empty lines are skipped. Quoted
+//! fields use the same minimal CSV convention as the WX-1 charset-torture
+//! corpus: a field starts with `"` and ends with `"`; embedded `""` is a
+//! literal quote. No multi-line records.
+//!
+//! Steps 1-3 + 7 (NFKC, lowercase, combining-strip, sigma/folds, ASCII space
+//! collapse) are not exercised here — that scope belongs to the WX-1
+//! charset-torture corpus. Rows in this matrix vary along the §3.3.2
+//! step-4 / 5 / 6 / 8 axes.
+
+use std::fs;
+use std::path::PathBuf;
+
+use wxyc_etl::text::{
+    to_identity_match_form, to_identity_match_form_title,
+    to_identity_match_form_with_disambiguator_strip, to_identity_match_form_with_punctuation,
+};
+
+#[derive(Debug)]
+struct Row {
+    line_no: usize,
+    input: String,
+    expected: String,
+    variant: String,
+    category: String,
+    notes: String,
+}
+
+fn fixture_path() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/identity_normalization_cases.csv");
+    p
+}
+
+fn parse_fixture() -> Vec<Row> {
+    let text = fs::read_to_string(fixture_path()).expect("fixture file is missing");
+    let mut rows = Vec::new();
+    for (i, line) in text.lines().enumerate() {
+        let line_no = i + 1;
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        // Skip the header.
+        if line_no == 1 && trimmed.starts_with("input,") {
+            continue;
+        }
+        let fields = parse_csv_line(line);
+        assert_eq!(
+            fields.len(),
+            5,
+            "line {line_no} has {} fields, expected 5: {line:?}",
+            fields.len()
+        );
+        rows.push(Row {
+            line_no,
+            input: fields[0].clone(),
+            expected: fields[1].clone(),
+            variant: fields[2].clone(),
+            category: fields[3].clone(),
+            notes: fields[4].clone(),
+        });
+    }
+    rows
+}
+
+/// Minimal CSV parser. Handles quoted fields with `""` for embedded quotes.
+/// Ignores newlines inside quotes (we do not produce multi-line records).
+fn parse_csv_line(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut field = String::new();
+    let mut in_quotes = false;
+    let mut iter = line.chars().peekable();
+    while let Some(c) = iter.next() {
+        match (c, in_quotes) {
+            ('"', true) => {
+                if iter.peek() == Some(&'"') {
+                    field.push('"');
+                    iter.next();
+                } else {
+                    in_quotes = false;
+                }
+            }
+            ('"', false) => {
+                in_quotes = true;
+            }
+            (',', false) => {
+                out.push(std::mem::take(&mut field));
+            }
+            (other, _) => {
+                field.push(other);
+            }
+        }
+    }
+    out.push(field);
+    out
+}
+
+fn apply(variant: &str, input: &str) -> String {
+    match variant {
+        "base" => to_identity_match_form(input),
+        "title" => to_identity_match_form_title(input),
+        "punct" => to_identity_match_form_with_punctuation(input),
+        "disamb" => to_identity_match_form_with_disambiguator_strip(input),
+        other => panic!("unknown variant {other:?}"),
+    }
+}
+
+#[test]
+fn identity_normalization_parity_matrix() {
+    let rows = parse_fixture();
+    assert!(
+        rows.len() >= 250,
+        "fixture must have ≥250 rows per plan §3.3.3, found {}",
+        rows.len()
+    );
+    let mut failures: Vec<String> = Vec::new();
+    for row in &rows {
+        let got = apply(&row.variant, &row.input);
+        if got != row.expected {
+            failures.push(format!(
+                "  line {} [{}/{}] input={:?}\n    expected={:?}\n         got={:?}\n    notes={:?}",
+                row.line_no, row.variant, row.category, row.input, row.expected, got, row.notes
+            ));
+        }
+    }
+    if !failures.is_empty() {
+        panic!(
+            "{} of {} parity rows failed:\n{}",
+            failures.len(),
+            rows.len(),
+            failures.join("\n")
+        );
+    }
+}
+
+#[test]
+fn fixture_meets_categorical_coverage_minimums() {
+    let rows = parse_fixture();
+    let mut counts = std::collections::HashMap::<String, usize>::new();
+    for row in &rows {
+        *counts.entry(row.category.clone()).or_default() += 1;
+    }
+    // Per plan §3.3.3 categorical coverage minimums.
+    let required: &[(&str, usize)] = &[
+        ("trailing-parens-artist", 50),
+        ("trailing-parens-title", 50),
+        ("leading-article", 25),
+        ("punct", 50),
+        ("disamb", 50),
+        ("disamb-title-negative", 25),
+    ];
+    let mut shortfalls = Vec::new();
+    for (cat, min) in required {
+        let got = counts.get(*cat).copied().unwrap_or(0);
+        if got < *min {
+            shortfalls.push(format!("  {cat}: got {got}, need ≥{min}"));
+        }
+    }
+    if !shortfalls.is_empty() {
+        panic!(
+            "categorical coverage shortfalls:\n{}",
+            shortfalls.join("\n")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

PR-B of three for [#99](https://github.com/WXYC/wxyc-etl/issues/99). Builds on [#100](https://github.com/WXYC/wxyc-etl/pull/100) (PR-A baseline). Adds the opt-in step-6 / step-8 variants and the locked parity-test fixture per [`docs/normalization.md`](https://github.com/WXYC/wxyc-etl/blob/main/docs/normalization.md) and plan [§3.3.3](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization-plan.md#333-parity-test-matrix-mandatory-before-any-cache-writes).

> ⚠️ **Stacked on [#100](https://github.com/WXYC/wxyc-etl/pull/100).** Base branch is `cross-cache-identity/e3-step-4-rust-core`. Re-target to `main` once PR-A merges.

## New public API

| Function | Adds | Layer |
|---|---|---|
| `to_identity_match_form_title` | nothing today | type-distinct symbol so titles can never accidentally call the artist-only disambiguator strip |
| `to_identity_match_form_with_punctuation` | plan [§3.3.2](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization-plan.md#332-algorithm-locked-except-where-noted) step 6 | Unicode-aware punctuation→space collapse; letters/numbers in any script survive |
| `to_identity_match_form_with_disambiguator_strip` | plan [§3.3.2](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization-plan.md#332-algorithm-locked-except-where-noted) step 8 | trailing `\s+/\d+` strip; whitespace before `/` is required (artists only) |

PyO3 bindings mirror the Rust surface under `wxyc_etl.text`.

## Parity matrix

`wxyc-etl/tests/fixtures/identity_normalization_cases.csv` — **252 rows**, meets every plan [§3.3.3](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization-plan.md#333-parity-test-matrix-mandatory-before-any-cache-writes) categorical minimum:

| Category | Min | Got |
|---|---|---|
| `trailing-parens-artist` | 50 | 50 |
| `trailing-parens-title` | 50 | 50 |
| `leading-article` | 25 | 25 |
| `punct` | 50 | 50 |
| `disamb` | 50 | 50 |
| `disamb-title-negative` | 25 | 25 |

Steps 1-3 + 7 coverage stays delegated to the WX-1 charset-torture corpus.

The Rust integration test `wxyc-etl/tests/identity_normalization_parity.rs` asserts row-by-row parity (252 cases) plus a categorical-coverage gate test that fails the build if any minimum slips below threshold.

## Spec disagreements surfaced and resolved

Authoring the matrix surfaced three places where my hand-traced "expected" disagreed with the algorithm. All three were resolved in favor of the spec, documented inline:

- Title variant runs the full baseline (includes article drop): `The Cat in the Hat (Original)` → `cat in the hat`. Spec says `_title` only opts out of step 8.
- Paren strip is single-pass outermost-only with depth tracking: `Stereolab (Live (1999)` → `stereolab (live`, not `stereolab` — the unbalanced inner-open is consumed by the outer scan but the outer ` (1999)` is not balanced any further.
- Disambiguator strip on `Beatles, The /1` leaves `beatles, the` (the trailing-comma article form does not re-fire after `/1` is removed; the algorithm makes one pass).

## Diff size

868 LOC across 7 files.

## Test results

- 60 new Rust unit tests in `identity.rs` + 252 parity rows + 2 coverage gate tests = all pass.
- 28 new Python parity cases + Optional[str] coverage extended to all 4 identity functions = all pass.
- `cargo test --workspace`: **467 pass / 0 fail**.
- `cargo clippy --workspace --all-targets` (CI allow-list): **clean**.
- `cargo fmt --check`: **clean**.
- `pytest wxyc-etl-python/tests/`: **428 pass / 1 skipped**.

## Out of scope

- Regression-report harness against real Homebrew caches → **PR-C**.
- 0.3.0 version bump → **PR-C** (or small follow-up).
- Postgres analog `wxyc_identity_match_artist` → separate per-cache PRs after Rust surface lands.

Closes part of [#99](https://github.com/WXYC/wxyc-etl/issues/99).