### PR TITLE
#114 bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/check-ci-marker-sync.yml
+++ b/.github/workflows/check-ci-marker-sync.yml
@@ -40,18 +40,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout calling repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: target-repo
 
       - name: Checkout wxyc-etl (for the script)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: WXYC/wxyc-etl
           ref: ${{ inputs.wxyc-etl-ref }}
           path: wxyc-etl
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
@@ -34,7 +34,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - name: Run Rust tests (PG tests skip without TEST_DATABASE_URL)
         run: cargo test --workspace
@@ -56,7 +56,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - name: Install wxyc_unaccent rules into the PG service container
         # The Postgres `unaccent` extension loads custom rules files from the
@@ -91,8 +91,8 @@ jobs:
   python-wheel:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@stable
@@ -111,8 +111,8 @@ jobs:
   marker-sync-self-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install pyyaml pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     outputs:
       version: ${{ steps.v.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: v
         name: Verify Cargo.toml version matches tag
         shell: bash
@@ -52,7 +52,7 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - name: cargo publish (dry-run)
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
@@ -79,8 +79,8 @@ jobs:
           - { os: macos-latest,      target: aarch64-apple-darwin,      manylinux: '' }
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       # `-i python3.12` tells maturin which interpreter headers to build against
@@ -103,7 +103,7 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: PyO3/maturin-action@v1
         with:
           working-directory: wxyc-etl-python


### PR DESCRIPTION
Closes #114.

## Summary

- `actions/checkout@v4 → @v6` (12 occurrences)
- `actions/setup-python@v5 → @v6` (4 occurrences)
- No `codecov/codecov-action` in this repo, so no input renames needed

Affected files: `.github/workflows/check-ci-marker-sync.yml`, `ci.yml`, `release.yml`. `charset-corpus-drift.yml` has no pins to bump.

## Why

GitHub Actions runners will force Node.js 24 by default starting **2026-06-02**, and Node.js 20 will be removed from the runner on **2026-09-16**. Every CI run currently emits the deprecation annotation. `check-ci-marker-sync.yml` is the reusable workflow consumed by sibling Python repos (verified consumer: [WXYC/library-metadata-lookup#300](https://github.com/WXYC/library-metadata-lookup/pull/300), which still emits the annotation sourced from this workflow), so the bump benefits multiple repos at once.

## Verification

Verified each target major against the authoritative upstream repo:

| Action | Target | Current latest | Notes |
|---|---|---|---|
| `actions/checkout@v6` | `93cb6efe... → v6.0.2` | v6.0.2 (2026-01-09) | Node.js 24 introduced in v5.0.0; v6 added creds-file hardening + user-agent. No input/output changes vs v5. |
| `actions/setup-python@v6` | `a309ff8b... → v6.2.0` | v6.2.0 (2026-01-22) | Node.js 24-compatible. `cache: pip` and `python-version` inputs unchanged. |

`actionlint .github/workflows/*.yml` clean.

## Test plan

- [x] `actionlint` clean
- [x] YAML parses
- [ ] This repo's CI run is green on the new versions
- [ ] After merge, the deprecation annotation no longer appears on consuming repos' CI runs (will verify by re-running CI on a current LML PR)
