### PR TITLE
Bump check-ci-marker-sync reusable workflow to Node 24-compatible actions

### DIFF
--- a/.github/workflows/check-ci-marker-sync.yml
+++ b/.github/workflows/check-ci-marker-sync.yml
@@ -40,18 +40,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout calling repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: target-repo
 
       - name: Checkout wxyc-etl (for the script)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: WXYC/wxyc-etl
           ref: ${{ inputs.wxyc-etl-ref }}
           path: wxyc-etl
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
Closes #116.

This reusable workflow is invoked from every WXYC repo with a pytest marker scheme. Pinning to `actions/checkout@v4` and `actions/setup-python@v5` caused every consuming repo's CI run to emit Node 20 deprecation annotations even after they bumped their own action pins (verified post-merge of [WXYC/request-o-matic#121](https://github.com/WXYC/request-o-matic/pull/121) — the only remaining Node 20 annotation on rom's `main` runs comes from this file).

- `actions/checkout` v4 → v6
- `actions/setup-python` v5 → v6

No input/behavior change. Versions match the same bump just landed in `request-o-matic`. Consumers reference this workflow at `@main`, so the moment this merges every consumer picks it up automatically — no downstream PRs needed.

## Verification

- YAML parses cleanly.
- `actions/checkout@v6` and `actions/setup-python@v6` were exercised end-to-end by `request-o-matic` CI run [25710983583](https://github.com/WXYC/request-o-matic/actions/runs/25710983583), which is green; same usage pattern (no inputs beyond `path:`, `repository:`, `ref:`, `python-version:`).

## Test plan

- [ ] PR's own CI (if any) is green.
- [ ] After merge, trigger a fresh CI run on `request-o-matic` (e.g. by re-running the latest `main` workflow) and confirm zero Node 20 deprecation annotations.