### PR TITLE
feat(infra): publish wxyc-postgres image with wxyc_unaccent.rules baked in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,8 +222,12 @@ jobs:
     needs: [publish-crate, build-wheels, build-sdist]
     runs-on: ubuntu-latest
     steps:
+      # Filter to wheels + sdist only. docker/build-push-action@v6 uploads
+      # opaque `*.dockerbuild` provenance artifacts to the run that would
+      # otherwise be pulled in here and fail the download step.
       - uses: actions/download-artifact@v4
         with:
+          pattern: "{wheel-*,sdist}"
           path: dist
           merge-multiple: true
       - name: List artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,28 +176,37 @@ jobs:
           SHAREDIR="/usr/share/postgresql/${PG}"
           EXPECTED_SHA=$(sha256sum data/wxyc_unaccent.rules | awk '{print $1}')
           docker run --rm -d --name wxyc-pg-smoke -e POSTGRES_PASSWORD=smoke "$IMG"
-          # Wait for PG to accept connections (up to 60s)
+          # Unconditional cleanup + log dump on any exit path so the container
+          # never lingers and a failed step always surfaces PG startup output.
+          trap 'docker logs wxyc-pg-smoke 2>&1 || true; docker stop wxyc-pg-smoke >/dev/null 2>&1 || true' EXIT
+          # Wait for PG to accept connections (up to 60s); fail fast if it never does.
+          READY=0
           for _ in $(seq 1 60); do
-            if docker exec wxyc-pg-smoke pg_isready -U postgres >/dev/null 2>&1; then break; fi
+            if docker exec wxyc-pg-smoke pg_isready -U postgres >/dev/null 2>&1; then
+              READY=1
+              break
+            fi
             sleep 1
           done
+          if [[ "$READY" -ne 1 ]]; then
+            echo "::error ::Postgres did not become ready within 60s"
+            exit 1
+          fi
           ACTUAL_SHA=$(docker exec wxyc-pg-smoke sha256sum "${SHAREDIR}/tsearch_data/wxyc_unaccent.rules" | awk '{print $1}')
           if [[ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]]; then
             echo "::error ::wxyc_unaccent.rules SHA-256 mismatch in image: expected $EXPECTED_SHA, got $ACTUAL_SHA"
-            docker logs wxyc-pg-smoke || true
-            docker stop wxyc-pg-smoke || true
             exit 1
           fi
           STAT_OK=$(docker exec wxyc-pg-smoke psql -U postgres -t -A -c \
             "SELECT (pg_stat_file('${SHAREDIR}/tsearch_data/wxyc_unaccent.rules')).size > 0;")
           if [[ "$STAT_OK" != "t" ]]; then
             echo "::error ::pg_stat_file did not report a non-empty rules file: $STAT_OK"
-            docker stop wxyc-pg-smoke || true
             exit 1
           fi
+          # DROP IF EXISTS keeps the smoke idempotent across job re-runs even
+          # though `docker run --rm` discards the container each time.
           RESULT=$(docker exec wxyc-pg-smoke psql -U postgres -t -A -c \
-            "CREATE EXTENSION IF NOT EXISTS unaccent; CREATE TEXT SEARCH DICTIONARY wxyc_unaccent (TEMPLATE = unaccent, RULES = 'wxyc_unaccent'); SELECT ts_lexize('wxyc_unaccent', 'café');")
-          docker stop wxyc-pg-smoke
+            "CREATE EXTENSION IF NOT EXISTS unaccent; DROP TEXT SEARCH DICTIONARY IF EXISTS wxyc_unaccent; CREATE TEXT SEARCH DICTIONARY wxyc_unaccent (TEMPLATE = unaccent, RULES = 'wxyc_unaccent'); SELECT ts_lexize('wxyc_unaccent', 'café');")
           if [[ "$RESULT" != *"{cafe}"* ]]; then
             echo "::error ::ts_lexize('wxyc_unaccent', 'café') returned unexpected: $RESULT"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,20 @@
 name: Release
 
-# Tag-driven publish for both halves of the wxyc-etl workspace.
+# Tag-driven publish for both halves of the wxyc-etl workspace plus the
+# wxyc-postgres Docker image.
 #
 #   git tag v0.1.0 && git push origin v0.1.0
 #
 # A `workflow_dispatch` run with `dry_run: true` (the default) is the safe way
-# to rehearse the pipeline without touching crates.io or PyPI. It runs every
-# build + a `cargo publish --dry-run` and skips the actual upload steps.
+# to rehearse the pipeline without touching crates.io, PyPI, or GHCR. It runs
+# every build + a `cargo publish --dry-run` + a local image build + smoke test,
+# and skips the actual upload / push steps.
 #
 # Required repo secrets (set up once in GitHub → Settings → Secrets):
 #   CRATES_IO_TOKEN   API token from https://crates.io/me — needs `publish-new` + `publish-update` scopes
 #   PYPI_API_TOKEN    API token from https://pypi.org/manage/account/token/ — scope to the `wxyc-etl` project after first publish
+# GHCR uses the default GITHUB_TOKEN with `packages: write` granted on the
+# publish-postgres-image job — no separate secret needed.
 
 on:
   push:
@@ -18,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Skip cargo/PyPI uploads (rehearsal mode)"
+        description: "Skip cargo/PyPI/GHCR uploads (rehearsal mode)"
         type: boolean
         default: true
 
@@ -113,6 +117,106 @@ jobs:
         with:
           name: sdist
           path: wxyc-etl-python/dist
+
+  publish-postgres-image:
+    needs: verify
+    name: image pg${{ matrix.pg }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pg: "17"
+            dockerfile: infra/wxyc-postgres/Dockerfile.pg17
+          - pg: "16"
+            dockerfile: infra/wxyc-postgres/Dockerfile.pg16
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compute tags
+        id: tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.verify.outputs.version }}"
+          PG="${{ matrix.pg }}"
+          FLOATING="ghcr.io/wxyc/wxyc-postgres:pg${PG}"
+          PINNED="ghcr.io/wxyc/wxyc-postgres:pg${PG}-v${VERSION}"
+          echo "floating=${FLOATING}" >> "$GITHUB_OUTPUT"
+          {
+            echo "tags<<EOF"
+            echo "${FLOATING}"
+            echo "${PINNED}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Build (local, single-arch) for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          load: true
+          platforms: linux/amd64
+          tags: ${{ steps.tags.outputs.floating }}
+      - name: Smoke test
+        shell: bash
+        env:
+          PG: ${{ matrix.pg }}
+        run: |
+          set -euo pipefail
+          IMG="${{ steps.tags.outputs.floating }}"
+          SHAREDIR="/usr/share/postgresql/${PG}"
+          EXPECTED_SHA=$(sha256sum data/wxyc_unaccent.rules | awk '{print $1}')
+          docker run --rm -d --name wxyc-pg-smoke -e POSTGRES_PASSWORD=smoke "$IMG"
+          # Wait for PG to accept connections (up to 60s)
+          for _ in $(seq 1 60); do
+            if docker exec wxyc-pg-smoke pg_isready -U postgres >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          ACTUAL_SHA=$(docker exec wxyc-pg-smoke sha256sum "${SHAREDIR}/tsearch_data/wxyc_unaccent.rules" | awk '{print $1}')
+          if [[ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]]; then
+            echo "::error ::wxyc_unaccent.rules SHA-256 mismatch in image: expected $EXPECTED_SHA, got $ACTUAL_SHA"
+            docker logs wxyc-pg-smoke || true
+            docker stop wxyc-pg-smoke || true
+            exit 1
+          fi
+          STAT_OK=$(docker exec wxyc-pg-smoke psql -U postgres -t -A -c \
+            "SELECT (pg_stat_file('${SHAREDIR}/tsearch_data/wxyc_unaccent.rules')).size > 0;")
+          if [[ "$STAT_OK" != "t" ]]; then
+            echo "::error ::pg_stat_file did not report a non-empty rules file: $STAT_OK"
+            docker stop wxyc-pg-smoke || true
+            exit 1
+          fi
+          RESULT=$(docker exec wxyc-pg-smoke psql -U postgres -t -A -c \
+            "CREATE EXTENSION IF NOT EXISTS unaccent; CREATE TEXT SEARCH DICTIONARY wxyc_unaccent (TEMPLATE = unaccent, RULES = 'wxyc_unaccent'); SELECT ts_lexize('wxyc_unaccent', 'café');")
+          docker stop wxyc-pg-smoke
+          if [[ "$RESULT" != *"{cafe}"* ]]; then
+            echo "::error ::ts_lexize('wxyc_unaccent', 'café') returned unexpected: $RESULT"
+            exit 1
+          fi
+      - name: Build + push (multi-arch)
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run) }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.tags.outputs.tags }}
+      - name: Skip push (dry-run)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        shell: bash
+        run: |
+          echo "Dry-run mode: would push the following tags to GHCR:"
+          echo "${{ steps.tags.outputs.tags }}"
 
   publish-pypi:
     needs: [publish-crate, build-wheels, build-sdist]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,8 @@ jobs:
           set -euo pipefail
           IMG="${{ steps.tags.outputs.floating }}"
           SHAREDIR="/usr/share/postgresql/${PG}"
-          EXPECTED_SHA=$(sha256sum data/wxyc_unaccent.rules | awk '{print $1}')
+          EXPECTED_RULES_SHA=$(sha256sum data/wxyc_unaccent.rules | awk '{print $1}')
+          EXPECTED_VERSION_SHA=$(sha256sum data/wxyc_unaccent.version | awk '{print $1}')
           docker run --rm -d --name wxyc-pg-smoke -e POSTGRES_PASSWORD=smoke "$IMG"
           # Unconditional cleanup + log dump on any exit path so the container
           # never lingers and a failed step always surfaces PG startup output.
@@ -192,15 +193,31 @@ jobs:
             echo "::error ::Postgres did not become ready within 60s"
             exit 1
           fi
-          ACTUAL_SHA=$(docker exec wxyc-pg-smoke sha256sum "${SHAREDIR}/tsearch_data/wxyc_unaccent.rules" | awk '{print $1}')
-          if [[ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]]; then
-            echo "::error ::wxyc_unaccent.rules SHA-256 mismatch in image: expected $EXPECTED_SHA, got $ACTUAL_SHA"
+          ACTUAL_RULES_SHA=$(docker exec wxyc-pg-smoke sha256sum "${SHAREDIR}/tsearch_data/wxyc_unaccent.rules" | awk '{print $1}')
+          if [[ "$ACTUAL_RULES_SHA" != "$EXPECTED_RULES_SHA" ]]; then
+            echo "::error ::wxyc_unaccent.rules SHA-256 mismatch in image: expected $EXPECTED_RULES_SHA, got $ACTUAL_RULES_SHA"
+            exit 1
+          fi
+          # Verify the .version companion landed too. Dockerfile COPYs both
+          # files; if a future edit drops the .version COPY, the rules-only
+          # checks above would still pass green and consumers that introspect
+          # the version file (per docs/wxyc-postgres-image.md) would silently
+          # see a stock-base image.
+          ACTUAL_VERSION_SHA=$(docker exec wxyc-pg-smoke sha256sum "${SHAREDIR}/tsearch_data/wxyc_unaccent.version" | awk '{print $1}')
+          if [[ "$ACTUAL_VERSION_SHA" != "$EXPECTED_VERSION_SHA" ]]; then
+            echo "::error ::wxyc_unaccent.version SHA-256 mismatch in image: expected $EXPECTED_VERSION_SHA, got $ACTUAL_VERSION_SHA"
             exit 1
           fi
           STAT_OK=$(docker exec wxyc-pg-smoke psql -U postgres -t -A -c \
             "SELECT (pg_stat_file('${SHAREDIR}/tsearch_data/wxyc_unaccent.rules')).size > 0;")
           if [[ "$STAT_OK" != "t" ]]; then
             echo "::error ::pg_stat_file did not report a non-empty rules file: $STAT_OK"
+            exit 1
+          fi
+          VERSION_STAT_OK=$(docker exec wxyc-pg-smoke psql -U postgres -t -A -c \
+            "SELECT (pg_stat_file('${SHAREDIR}/tsearch_data/wxyc_unaccent.version')).size > 0;")
+          if [[ "$VERSION_STAT_OK" != "t" ]]; then
+            echo "::error ::pg_stat_file did not report a non-empty version file: $VERSION_STAT_OK"
             exit 1
           fi
           # DROP IF EXISTS keeps the smoke idempotent across job re-runs even

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,19 @@ The workflow declares no `permissions:` block of its own — it doesn't write an
 
 Watch for the **caller-callee narrowing trap** when adding a `permissions:` block to this workflow: if a reusable workflow declares `contents: write` at the workflow level (e.g., to push a fix-up commit) but its callers hardened to `contents: read`, the matrix run startup_failures with no jobs and no obvious error. See [WXYC/Backend-Service#857](https://github.com/WXYC/Backend-Service/issues/857) (silent for 10 commits across 2 days) and PR [#858](https://github.com/WXYC/Backend-Service/pull/858) for the recovery pattern. `check-ci-marker-sync.yml` is read-only today, so it can't trip this — but the trap applies to any future revision that takes a write scope, and a `gha/v2` migration is the safest way to surface it.
 
+### Docker image consumers (`ghcr.io/wxyc/wxyc-postgres`)
+
+This repo also publishes the `wxyc-postgres` image (see `infra/wxyc-postgres/` and `docs/wxyc-postgres-image.md`), consumed by Railway PG services in discogs-cache, musicbrainz-cache, and wikidata-cache. Image tags are a separate consumer contract:
+
+| Tag | Consumer expectation |
+|---|---|
+| `:pg17`, `:pg16` | Floating. Moves on every wxyc-etl release. Suitable for staging. |
+| `:pg17-v0.4.X`, `:pg16-v0.4.X` | Pinned. Production Railway services pin here; rollback target. |
+
+The base image must stay on `ghcr.io/railwayapp-templates/postgres-ssl:N@sha256:<digest>` (digest-pinned, not floating). Refreshing the base digest is a release event — bump `Cargo.toml`, tag, ship a new pinned image, then operators swap each Railway PG one-by-one. **Don't move the base off `railwayapp-templates/postgres-ssl`** — Railway services depend on its SSL init hook, pgbackrest, pgvector, and `wrapper.sh` entrypoint; switching to stock `postgres:N` would silently strip all four.
+
+A behavior change in `data/wxyc_unaccent.rules` (the bytes consumers see at `$SHAREDIR/tsearch_data/wxyc_unaccent.rules` after swap) is breaking. Today the rules file is the canonical Postgres-side counterpart to `strip_combining_selective + apply_folds`, locked by `wxyc-etl/tests/wxyc_unaccent_rules_test.rs` against the Rust generator; any change to `to_match_form` flows through that test to a new bytes-on-disk for every consumer. Coordinate with the three cache repos before merging such a change.
+
 ## Workspace Layout
 
 Cargo workspace with two members:
@@ -267,7 +280,7 @@ Intentional opt-out for a marker that is, by design, manual-only: add `# ci-sync
 
 ## Releases
 
-Both halves of the workspace publish from the same tag — `wxyc-etl` to crates.io, `wxyc-etl-python` to PyPI. The workspace `version` in the root `Cargo.toml` is the single source of truth; both crates inherit it via `version.workspace = true` and maturin reads it via `pyproject.toml`'s `dynamic = ["version"]`.
+Three artifacts publish from the same tag — `wxyc-etl` to crates.io, `wxyc-etl-python` to PyPI, and `ghcr.io/wxyc/wxyc-postgres:{pg17,pg16}` to GHCR. The workspace `version` in the root `Cargo.toml` is the single source of truth; both crates inherit it via `version.workspace = true`, maturin reads it via `pyproject.toml`'s `dynamic = ["version"]`, and the Docker image tags it as `:pgN-vX.Y.Z` alongside the floating `:pgN`.
 
 ### Cutting a release
 
@@ -286,10 +299,13 @@ The `release.yml` workflow fires on tags matching `v*.*.*`. It:
 2. `cargo publish -p wxyc-etl` to crates.io.
 3. Builds wheels for `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin` plus an sdist.
 4. `maturin upload --skip-existing dist/*` to PyPI.
+5. Builds + smoke-tests `ghcr.io/wxyc/wxyc-postgres:pg17` and `:pg16` (single-arch local build, `pg_stat_file` + `ts_lexize('wxyc_unaccent', 'café')` against the running container, SHA-256 of the rules file inside the image vs. `data/wxyc_unaccent.rules` on disk). Then `docker/build-push-action@v6` pushes both arches (`linux/amd64`, `linux/arm64`) with floating + pinned tags.
+
+The base for the image is digest-pinned in `infra/wxyc-postgres/Dockerfile.pgN`. Refreshing it is a release event — see `docs/wxyc-postgres-image.md` for the procedure.
 
 ### Rehearsing a release
 
-Use the `workflow_dispatch` trigger with `dry_run: true` (the default). It runs every build step + a `cargo publish --dry-run` and skips the actual upload steps. Safe to run any time.
+Use the `workflow_dispatch` trigger with `dry_run: true` (the default). It runs every build step + a `cargo publish --dry-run` + a local image build with smoke test, and skips the actual upload / push steps. Safe to run any time.
 
 ### Required repo secrets
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ This repo also publishes the `wxyc-postgres` image (see `infra/wxyc-postgres/` a
 | Tag | Consumer expectation |
 |---|---|
 | `:pg17`, `:pg16` | Floating. Moves on every wxyc-etl release. Suitable for staging. |
-| `:pg17-v0.4.X`, `:pg16-v0.4.X` | Pinned. Production Railway services pin here; rollback target. |
+| `:pg17-vMAJOR.MINOR.PATCH`, `:pg16-vMAJOR.MINOR.PATCH` | Pinned (e.g. `:pg17-v0.4.1`). Production Railway services pin here; rollback target. |
 
 The base image must stay on `ghcr.io/railwayapp-templates/postgres-ssl:N@sha256:<digest>` (digest-pinned, not floating). Refreshing the base digest is a release event — bump `Cargo.toml`, tag, ship a new pinned image, then operators swap each Railway PG one-by-one. **Don't move the base off `railwayapp-templates/postgres-ssl`** — Railway services depend on its SSL init hook, pgbackrest, pgvector, and `wrapper.sh` entrypoint; switching to stock `postgres:N` would silently strip all four.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3133,7 +3133,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wxyc-etl"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "wxyc-etl-python"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,6 @@ members = ["wxyc-etl", "wxyc-etl-python"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT"

--- a/docs/wxyc-postgres-image.md
+++ b/docs/wxyc-postgres-image.md
@@ -1,0 +1,92 @@
+# wxyc-postgres Docker image
+
+Operator runbook for the `ghcr.io/wxyc/wxyc-postgres` image: a thin overlay over Railway's `ghcr.io/railwayapp-templates/postgres-ssl:N` base that bakes the WXYC `wxyc_unaccent.rules` text-search dictionary into `$SHAREDIR/tsearch_data/`. Built and published from this repo on every `v*.*.*` tag.
+
+The image exists because Postgres looks up `RULES = 'wxyc_unaccent'` against the destination PG's filesystem at `$SHAREDIR/tsearch_data/wxyc_unaccent.rules`, and stock PG images can't self-provision that file at migration time (`/usr/local/share/postgresql/tsearch_data/` is `root:root 0755`, postgres user uid 70 gets EACCES on any write). See WXYC/Backend-Service#805 for the parallel RDS-side outcome that drove WXYC to the Python-analog there; this image is the Railway-side equivalent for the three caches.
+
+## What's in the image
+
+- Everything from `ghcr.io/railwayapp-templates/postgres-ssl:N` — Postgres N, the `init-ssl.sh` initdb hook, `pgbackrest`, `pgvector`, the `wrapper.sh` entrypoint Railway services rely on.
+- `data/wxyc_unaccent.rules` from this repo, copied to `/usr/share/postgresql/N/tsearch_data/wxyc_unaccent.rules` (`$SHAREDIR/tsearch_data/`).
+- `data/wxyc_unaccent.version` from this repo, copied alongside for version introspection.
+
+The image is a pure overlay — no other config or behavior change. Pulling `:pgN` instead of `ghcr.io/railwayapp-templates/postgres-ssl:N` produces a byte-identical Postgres instance with two extra files on disk.
+
+## Tags
+
+| Tag | Meaning |
+|---|---|
+| `:pg17` | Latest wxyc-etl release on Postgres 17. Moves on each release. |
+| `:pg16` | Latest wxyc-etl release on Postgres 16. Moves on each release. |
+| `:pg17-v0.4.1` | Pinned to a specific wxyc-etl release. Preferred for reproducible CI and rollback targets. |
+| `:pg16-v0.4.1` | Pinned. Same rules. |
+
+Both arches (linux/amd64 + linux/arm64) ship under every tag.
+
+## Railway PG service swap (operator procedure)
+
+The Railway PG plugin lets you swap the underlying image without touching the data volume. Per-cache, one-time operation:
+
+1. Open the Railway dashboard → the cache's project (`discogs-cache`, `musicbrainz-cache`, or `wikidata-cache`).
+2. Click the **Postgres** service → **Settings** → **Source**.
+3. Change **Image** from `ghcr.io/railwayapp-templates/postgres-ssl:N` to `ghcr.io/wxyc/wxyc-postgres:pgN-vX.Y.Z` (or `:pgN` for the floating tag — pin to a versioned tag in production, floating is fine for staging).
+4. Click **Deploy** at the bottom of the panel. Railway will stop the old container and start a new one against the same volume. Downtime is typically 30-60s.
+5. Once the new deploy is green, verify the dictionary is live:
+
+```sql
+-- From the cache's `Apply pending alembic migrations` /  `sqlx migrate run` runner,
+-- or via Railway's "Connect" → SQL panel:
+SELECT ts_lexize('wxyc_unaccent', 'café');
+-- Expected: {cafe}
+```
+
+If you see `{cafe}`, the rules file is on disk and the migration's `CREATE TEXT SEARCH DICTIONARY` step will succeed against this PG.
+
+6. (Optional, for the paranoid) confirm the file landed. The PG version is in the path — `16` for `:pg16`, `17` for `:pg17`:
+
+```sql
+SELECT pg_stat_file('/usr/share/postgresql/17/tsearch_data/wxyc_unaccent.rules');
+-- Expected: (size, atime, mtime, ctime, false) tuple — not an error.
+```
+
+## Rollback
+
+Same procedure in reverse:
+
+1. Railway → service → **Settings** → **Source** → set **Image** back to `ghcr.io/railwayapp-templates/postgres-ssl:N`.
+2. **Deploy**.
+3. Migrations that reference `wxyc_unaccent` will fail with the now-actionable `F0000` error pointing back at this runbook. That's expected; rollback means dictionary-dependent migrations are off the menu until you re-swap.
+
+Data is unaffected. Existing rows already normalized via `wxyc_unaccent` stay normalized — only future calls to `ts_lexize('wxyc_unaccent', ...)` and `SELECT wxyc_unaccent(...)`-style references would fail.
+
+## Refreshing the base image (security updates)
+
+When `ghcr.io/railwayapp-templates/postgres-ssl:N` ships a security update:
+
+1. Look up the new digest:
+
+```bash
+gh api /orgs/railwayapp-templates/packages/container/postgres-ssl/versions \
+  --jq '.[] | select(.metadata.container.tags[] | startswith("17") or startswith("16")) | {tags: .metadata.container.tags, name: .name}'
+```
+
+2. Update the digest in both `infra/wxyc-postgres/Dockerfile.pg17` and `Dockerfile.pg16`.
+3. Bump the workspace version in `Cargo.toml` (patch-level — additive, no API change).
+4. `git tag v0.X.Y && git push origin v0.X.Y` — `release.yml` rebuilds and pushes the image to GHCR.
+5. Swap each cache's Railway PG service to the new versioned tag.
+
+## Refreshing the rules file
+
+Editing `data/wxyc_unaccent.rules` is owned by the generator at `wxyc-etl/tests/wxyc_unaccent_rules_test.rs`. Run with `WXYC_REGENERATE_RULES=1` after any `to_match_form` behavior change in the Rust crate. The `wxyc_unaccent.version` file is bumped by the same generator. Once committed:
+
+1. Bump `Cargo.toml` workspace version.
+2. Tag and push — `release.yml` picks up the new rules in the next image build.
+3. Swap each cache's Railway PG service to the new versioned tag. Re-running the cache's migration is a no-op (the `CREATE TEXT SEARCH DICTIONARY` step is `DROP IF EXISTS + CREATE`).
+
+## Why a custom image vs. self-provisioning at migration time
+
+Tried, infeasible. Verified 2026-05-20 against `postgres:16-alpine` (`/usr/local/share/postgresql/tsearch_data/`) and `ghcr.io/railwayapp-templates/postgres-ssl:17` (`/usr/share/postgresql/17/tsearch_data/`): the `postgres` OS user (uid 70) cannot write to `$SHAREDIR/tsearch_data/` (`root:root 0755`) regardless of which image layout the destination uses, so no `lo_export` / `COPY ... TO PROGRAM` / equivalent issued from inside a migration can land the file. The Backend-Service team hit the same constraint against AWS RDS and pivoted to the Python-analog path (WXYC/Backend-Service#805); the three caches stay on the Postgres-analog path by virtue of Railway exposing the image as a swappable property.
+
+## Visibility
+
+The image is **public** on GHCR. Bytes are the canonical rules file (already public in this repo's `data/`) plus the stock railwayapp-templates base; nothing sensitive ships in this layer.

--- a/docs/wxyc-postgres-image.md
+++ b/docs/wxyc-postgres-image.md
@@ -18,8 +18,8 @@ The image is a pure overlay — no other config or behavior change. Pulling `:pg
 |---|---|
 | `:pg17` | Latest wxyc-etl release on Postgres 17. Moves on each release. |
 | `:pg16` | Latest wxyc-etl release on Postgres 16. Moves on each release. |
-| `:pg17-v0.4.1` | Pinned to a specific wxyc-etl release. Preferred for reproducible CI and rollback targets. |
-| `:pg16-v0.4.1` | Pinned. Same rules. |
+| `:pg17-vMAJOR.MINOR.PATCH` | Pinned to a specific wxyc-etl release (e.g. `:pg17-v0.4.1`). Preferred for reproducible CI and rollback targets. |
+| `:pg16-vMAJOR.MINOR.PATCH` | Pinned to a specific wxyc-etl release (e.g. `:pg16-v0.4.1`). Same rules. |
 
 Both arches (linux/amd64 + linux/arm64) ship under every tag.
 
@@ -34,7 +34,7 @@ The Railway PG plugin lets you swap the underlying image without touching the da
 5. Once the new deploy is green, verify the dictionary is live:
 
 ```sql
--- From the cache's `Apply pending alembic migrations` /  `sqlx migrate run` runner,
+-- From the cache's `Apply pending alembic migrations` runner,
 -- or via Railway's "Connect" → SQL panel:
 SELECT ts_lexize('wxyc_unaccent', 'café');
 -- Expected: {cafe}

--- a/infra/wxyc-postgres/Dockerfile.pg16
+++ b/infra/wxyc-postgres/Dockerfile.pg16
@@ -11,6 +11,13 @@
 # Pinned digest sources: gh api /orgs/railwayapp-templates/packages/container/postgres-ssl/versions
 FROM ghcr.io/railwayapp-templates/postgres-ssl:16@sha256:73561b79111938f821de4d2530f7bb1736eed7b0d666b1a462c4f7e0f1b2a106
 
+# OCI image labels — GHCR uses `org.opencontainers.image.source` to wire the
+# package page to this repo (visibility inheritance, "view source" link,
+# README surfacing on the package landing page).
+LABEL org.opencontainers.image.source="https://github.com/WXYC/wxyc-etl"
+LABEL org.opencontainers.image.description="Railway postgres-ssl:16 with WXYC wxyc_unaccent.rules baked in"
+LABEL org.opencontainers.image.licenses="MIT"
+
 # $SHAREDIR on this base is /usr/share/postgresql/16 (Debian apt layout).
 # `pg_config --sharedir` reports the same. Confirm with:
 #   docker run --rm --entrypoint /bin/bash <image> -c 'pg_config --sharedir'

--- a/infra/wxyc-postgres/Dockerfile.pg16
+++ b/infra/wxyc-postgres/Dockerfile.pg16
@@ -1,0 +1,18 @@
+# wxyc-postgres:pg16 — Railway's postgres-ssl:16 with WXYC's text-search dictionary baked in.
+#
+# Build context is the wxyc-etl repo root. The canonical rules file lives at
+# data/wxyc_unaccent.rules and is the upstream source-of-truth for the four
+# identity-match entry points (Rust ↔ Postgres parity, see CLAUDE.md).
+#
+# Refresh procedure: when picking up an upstream postgres-ssl security update,
+# bump the digest below, push the tag, cut a new wxyc-etl release. The base
+# image preserves Railway's SSL init hook, pgbackrest, and pgvector intact.
+#
+# Pinned digest sources: gh api /orgs/railwayapp-templates/packages/container/postgres-ssl/versions
+FROM ghcr.io/railwayapp-templates/postgres-ssl:16@sha256:73561b79111938f821de4d2530f7bb1736eed7b0d666b1a462c4f7e0f1b2a106
+
+# $SHAREDIR on this base is /usr/share/postgresql/16 (Debian apt layout).
+# `pg_config --sharedir` reports the same. Confirm with:
+#   docker run --rm --entrypoint /bin/bash <image> -c 'pg_config --sharedir'
+COPY data/wxyc_unaccent.rules    /usr/share/postgresql/16/tsearch_data/wxyc_unaccent.rules
+COPY data/wxyc_unaccent.version  /usr/share/postgresql/16/tsearch_data/wxyc_unaccent.version

--- a/infra/wxyc-postgres/Dockerfile.pg17
+++ b/infra/wxyc-postgres/Dockerfile.pg17
@@ -11,6 +11,13 @@
 # Pinned digest sources: gh api /orgs/railwayapp-templates/packages/container/postgres-ssl/versions
 FROM ghcr.io/railwayapp-templates/postgres-ssl:17@sha256:2378464ce08af16eb18c87b8f4024edbb26f48d3e2641b5d238bf517709bb2da
 
+# OCI image labels — GHCR uses `org.opencontainers.image.source` to wire the
+# package page to this repo (visibility inheritance, "view source" link,
+# README surfacing on the package landing page).
+LABEL org.opencontainers.image.source="https://github.com/WXYC/wxyc-etl"
+LABEL org.opencontainers.image.description="Railway postgres-ssl:17 with WXYC wxyc_unaccent.rules baked in"
+LABEL org.opencontainers.image.licenses="MIT"
+
 # $SHAREDIR on this base is /usr/share/postgresql/17 (Debian apt layout).
 # `pg_config --sharedir` reports the same. Confirm with:
 #   docker run --rm --entrypoint /bin/bash <image> -c 'pg_config --sharedir'

--- a/infra/wxyc-postgres/Dockerfile.pg17
+++ b/infra/wxyc-postgres/Dockerfile.pg17
@@ -1,0 +1,18 @@
+# wxyc-postgres:pg17 — Railway's postgres-ssl:17 with WXYC's text-search dictionary baked in.
+#
+# Build context is the wxyc-etl repo root. The canonical rules file lives at
+# data/wxyc_unaccent.rules and is the upstream source-of-truth for the four
+# identity-match entry points (Rust ↔ Postgres parity, see CLAUDE.md).
+#
+# Refresh procedure: when picking up an upstream postgres-ssl security update,
+# bump the digest below, push the tag, cut a new wxyc-etl release. The base
+# image preserves Railway's SSL init hook, pgbackrest, and pgvector intact.
+#
+# Pinned digest sources: gh api /orgs/railwayapp-templates/packages/container/postgres-ssl/versions
+FROM ghcr.io/railwayapp-templates/postgres-ssl:17@sha256:2378464ce08af16eb18c87b8f4024edbb26f48d3e2641b5d238bf517709bb2da
+
+# $SHAREDIR on this base is /usr/share/postgresql/17 (Debian apt layout).
+# `pg_config --sharedir` reports the same. Confirm with:
+#   docker run --rm --entrypoint /bin/bash <image> -c 'pg_config --sharedir'
+COPY data/wxyc_unaccent.rules    /usr/share/postgresql/17/tsearch_data/wxyc_unaccent.rules
+COPY data/wxyc_unaccent.version  /usr/share/postgresql/17/tsearch_data/wxyc_unaccent.version


### PR DESCRIPTION
## Summary

Builds `ghcr.io/wxyc/wxyc-postgres:{pg17,pg16}` on every `v*.*.*` tag — a thin overlay over `ghcr.io/railwayapp-templates/postgres-ssl` that copies `data/wxyc_unaccent.rules` into `$SHAREDIR/tsearch_data/`. Unblocks the three caches (discogs-cache, musicbrainz-cache, wikidata-cache) running `CREATE TEXT SEARCH DICTIONARY wxyc_unaccent` against a fresh Railway PG without an operator-side `docker cp` step.

Postgres looks up `RULES = 'wxyc_unaccent'` at the destination PG's filesystem. Stock images can't self-provision the file (`root:root 0755` on tsearch_data, postgres uid 70 hits EACCES from any in-migration write attempt). Custom image is the viable path for Railway-hosted destinations; Backend-Service hit the same constraint on RDS and pivoted to the Python-analog ([WXYC/Backend-Service#805](https://github.com/WXYC/Backend-Service/issues/805)).

## What ships

- `infra/wxyc-postgres/Dockerfile.pg17` + `Dockerfile.pg16` — `FROM` digest-pinned `railwayapp-templates/postgres-ssl:N`, two `COPY`s into `/usr/share/postgresql/N/tsearch_data/` (Debian apt layout the base uses; verified empirically via `pg_config --sharedir` inside both images).
- `.github/workflows/release.yml` — new `publish-postgres-image` matrix job (pg17, pg16). Local single-arch build + smoke (SHA-256 byte equality vs `data/wxyc_unaccent.rules`, `(pg_stat_file).size > 0`, `ts_lexize('wxyc_unaccent', 'café') -> {cafe}`), then multi-arch push (`linux/amd64`, `linux/arm64`) via `docker/build-push-action@v6`. Uses `GITHUB_TOKEN` with `packages: write` — no new secret. Respects existing `workflow_dispatch.dry_run`.
- `docs/wxyc-postgres-image.md` — operator runbook: Railway swap procedure, rollback, post-swap verification, base-digest refresh, rules-file refresh.
- `CLAUDE.md` — Docker-image-consumers subsection under Tag Stability Policy (image tag stability is a separate consumer contract from the reusable workflow); Releases updated to mention the third artifact.
- `Cargo.toml` — workspace `0.4.0` → `0.4.1` (additive, no API change) so the image gets a first pinned tag `:pgN-v0.4.1`.

## Tag scheme

| Tag | Meaning |
|---|---|
| `:pg17`, `:pg16` | Floating. Moves on each wxyc-etl release. |
| `:pg17-v0.4.1`, `:pg16-v0.4.1` | Pinned. Reproducible CI / rollback target. |

## Test plan

- [x] **Local build pg16** — `docker build -f infra/wxyc-postgres/Dockerfile.pg16 .` succeeds.
- [x] **Local build pg17** — `docker build -f infra/wxyc-postgres/Dockerfile.pg17 .` succeeds.
- [x] **Local smoke pg16** — rules-file SHA matches `data/wxyc_unaccent.rules`, `pg_stat_file` reports non-empty file, `ts_lexize('wxyc_unaccent', 'café')` returns `{cafe}`.
- [x] **Local smoke pg17** — same checks pass.
- [x] **`$SHAREDIR` empirically verified** — `pg_config --sharedir` reports `/usr/share/postgresql/16` (and `…/17`) inside both bases; first smoke iteration caught a wrong path before the diff went out.
- [x] **YAML valid** — `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/release.yml"))'`.
- [x] **Cargo workspace inherits 0.4.1** — `cargo metadata` confirms `wxyc-etl 0.4.1` and `wxyc-etl-python 0.4.1`.
- [ ] **CI green on this PR.**
- [ ] **Tag-push rehearsal via `workflow_dispatch dry_run=true`** — runs the local build + smoke without pushing to GHCR. To be exercised after merge before cutting `v0.4.1`.

## Post-merge

1. `git tag v0.4.1 && git push origin v0.4.1` from `main`. Release workflow publishes the three artifacts (crate, wheels, image).
2. Operators swap each Railway PG service per the runbook (`docs/wxyc-postgres-image.md`).
3. Sibling caches' code-side work proceeds in parallel under [WXYC/discogs-etl#223](https://github.com/WXYC/discogs-etl/issues/223), [WXYC/musicbrainz-cache#56](https://github.com/WXYC/musicbrainz-cache/issues/56), [WXYC/wikidata-cache#41](https://github.com/WXYC/wikidata-cache/issues/41).

Closes #127.