### PR TITLE
feat(text): expose strip_leading_article as a public PyO3 binding

### DIFF
--- a/wxyc-etl-python/src/text.rs
+++ b/wxyc-etl-python/src/text.rs
@@ -155,11 +155,12 @@ fn to_identity_match_form_title(s: Option<&str>) -> String {
 /// Strip a leading article (`the`, `a`, `an`) from a lowercased + trimmed
 /// string. Returns the input unchanged when there is no leading article.
 ///
-/// The article must be followed by Unicode whitespace OR end-of-string,
-/// matching the `^(the|a|an)(\s+|$)` regex used by `library-metadata-lookup`.
-/// Bare-article inputs reduce to `""` (`strip_leading_article("the") == ""`);
-/// inputs without a word boundary after a candidate article are preserved
-/// verbatim (`strip_leading_article("theater") == "theater"`).
+/// The article must be followed by whitespace OR end-of-string, byte-for-byte
+/// matching CPython's `^(the|a|an)(\s+|$)` regex (`\s` = Unicode `White_Space`
+/// ∪ ASCII info separators U+001C..=U+001F). Bare-article inputs reduce to
+/// `""` (`strip_leading_article("the") == ""`); inputs without a word
+/// boundary after a candidate article are preserved verbatim
+/// (`strip_leading_article("theater") == "theater"`).
 ///
 /// Accepts None (returns "") so Python callers don't need to guard NULL.
 #[pyfunction]

--- a/wxyc-etl-python/src/text.rs
+++ b/wxyc-etl-python/src/text.rs
@@ -155,12 +155,11 @@ fn to_identity_match_form_title(s: Option<&str>) -> String {
 /// Strip a leading article (`the`, `a`, `an`) from a lowercased + trimmed
 /// string. Returns the input unchanged when there is no leading article.
 ///
-/// The article must be followed by ASCII whitespace OR end-of-string,
-/// mirroring the `^(the|a|an)(\s+|$)` regex used historically by
-/// `library-metadata-lookup`. Bare-article inputs reduce to `""`
-/// (`strip_leading_article("the") == ""`); inputs without a word boundary
-/// after a candidate article are preserved verbatim
-/// (`strip_leading_article("theater") == "theater"`).
+/// The article must be followed by Unicode whitespace OR end-of-string,
+/// matching the `^(the|a|an)(\s+|$)` regex used by `library-metadata-lookup`.
+/// Bare-article inputs reduce to `""` (`strip_leading_article("the") == ""`);
+/// inputs without a word boundary after a candidate article are preserved
+/// verbatim (`strip_leading_article("theater") == "theater"`).
 ///
 /// Accepts None (returns "") so Python callers don't need to guard NULL.
 #[pyfunction]

--- a/wxyc-etl-python/src/text.rs
+++ b/wxyc-etl-python/src/text.rs
@@ -16,6 +16,7 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(to_ascii_form, m)?)?;
     m.add_function(wrap_pyfunction!(to_identity_match_form, m)?)?;
     m.add_function(wrap_pyfunction!(to_identity_match_form_title, m)?)?;
+    m.add_function(wrap_pyfunction!(strip_leading_article, m)?)?;
     m.add_function(wrap_pyfunction!(
         to_identity_match_form_with_punctuation,
         m
@@ -149,6 +150,24 @@ fn to_identity_match_form(s: Option<&str>) -> String {
 fn to_identity_match_form_title(s: Option<&str>) -> String {
     s.map(wxyc_etl::text::to_identity_match_form_title)
         .unwrap_or_default()
+}
+
+/// Strip a leading article (`the`, `a`, `an`) from a lowercased + trimmed
+/// string. Returns the input unchanged when there is no leading article.
+///
+/// The article must be followed by ASCII whitespace OR end-of-string,
+/// mirroring the `^(the|a|an)(\s+|$)` regex used historically by
+/// `library-metadata-lookup`. Bare-article inputs reduce to `""`
+/// (`strip_leading_article("the") == ""`); inputs without a word boundary
+/// after a candidate article are preserved verbatim
+/// (`strip_leading_article("theater") == "theater"`).
+///
+/// Accepts None (returns "") so Python callers don't need to guard NULL.
+#[pyfunction]
+fn strip_leading_article(s: Option<&str>) -> String {
+    s.map(wxyc_etl::text::strip_leading_article)
+        .unwrap_or_default()
+        .to_string()
 }
 
 /// `to_identity_match_form` + plan §3.3.2 step 6: collapse runs of

--- a/wxyc-etl-python/tests/test_forms_none.py
+++ b/wxyc-etl-python/tests/test_forms_none.py
@@ -24,6 +24,7 @@ _FORMS = [
     text.to_identity_match_form_title,
     text.to_identity_match_form_with_punctuation,
     text.to_identity_match_form_with_disambiguator_strip,
+    text.strip_leading_article,
 ]
 _IDS = [
     "to_storage_form",
@@ -33,6 +34,7 @@ _IDS = [
     "to_identity_match_form_title",
     "to_identity_match_form_with_punctuation",
     "to_identity_match_form_with_disambiguator_strip",
+    "strip_leading_article",
 ]
 
 

--- a/wxyc-etl-python/tests/test_identity.py
+++ b/wxyc-etl-python/tests/test_identity.py
@@ -111,3 +111,35 @@ def test_with_punctuation(input_str: str, expected: str) -> None:
 )
 def test_with_disambiguator_strip(input_str: str, expected: str) -> None:
     assert text.to_identity_match_form_with_disambiguator_strip(input_str) == expected
+
+
+# --- standalone article stripper (PyO3-exposed; wxyc-etl#133) ---
+
+
+@pytest.mark.parametrize(
+    "input_str, expected",
+    [
+        ("the beatles", "beatles"),
+        ("a tribe called quest", "tribe called quest"),
+        ("an albatross", "albatross"),
+        ("the", ""),
+        ("a", ""),
+        ("an", ""),
+        ("theater", "theater"),
+        ("thee silver mt zion", "thee silver mt zion"),
+        ("animal", "animal"),
+        ("stereolab", "stereolab"),
+        ("the the", "the"),
+        ("the  beatles", "beatles"),
+        # Unicode whitespace after the article — matches Python `\s+` semantics.
+        ("the beatles", "beatles"),
+        ("the beatles", "beatles"),
+        ("the beatles", "beatles"),
+        ("the beatles", "beatles"),
+        # Input contract: lowercased + trimmed. Uppercased articles are a no-op.
+        ("The Beatles", "The Beatles"),
+        ("", ""),
+    ],
+)
+def test_strip_leading_article(input_str: str, expected: str) -> None:
+    assert text.strip_leading_article(input_str) == expected

--- a/wxyc-etl-python/tests/test_identity.py
+++ b/wxyc-etl-python/tests/test_identity.py
@@ -131,11 +131,18 @@ def test_with_disambiguator_strip(input_str: str, expected: str) -> None:
         ("stereolab", "stereolab"),
         ("the the", "the"),
         ("the  beatles", "beatles"),
-        # Unicode whitespace after the article — matches Python `\s+` semantics.
+        # Unicode whitespace after the article — matches CPython `re` `\s`.
         ("the beatles", "beatles"),
         ("the beatles", "beatles"),
         ("the beatles", "beatles"),
         ("the beatles", "beatles"),
+        # ASCII info separators are part of CPython's historical `\s` set.
+        ("thebeatles", "beatles"),
+        ("thebeatles", "beatles"),
+        ("thebeatles", "beatles"),
+        ("thebeatles", "beatles"),
+        # Heterogeneous whitespace run consumed greedily.
+        ("the  \t beatles", "beatles"),
         # Input contract: lowercased + trimmed. Uppercased articles are a no-op.
         ("The Beatles", "The Beatles"),
         ("", ""),

--- a/wxyc-etl/src/text/identity.rs
+++ b/wxyc-etl/src/text/identity.rs
@@ -540,8 +540,6 @@ mod tests {
 
     #[test]
     fn pub_strip_consumes_multiple_spaces_after_article() {
-        // Matches Python `\s+` semantics — consume all ASCII whitespace after
-        // the article boundary.
         assert_eq!(strip_leading_article("the  beatles"), "beatles");
         assert_eq!(strip_leading_article("a\ttribe"), "tribe");
     }

--- a/wxyc-etl/src/text/identity.rs
+++ b/wxyc-etl/src/text/identity.rs
@@ -233,7 +233,7 @@ fn strip_trailing_parens(s: &str) -> &str {
 /// and end-of-string after it; `Beatles, The` matches but
 /// `Beatles, the Best Of` does not.
 fn drop_articles(s: &str) -> String {
-    if let Some(rest) = strip_leading_article(s) {
+    if let Some(rest) = strip_leading_article_with_space_suffix(s) {
         return rest.to_string();
     }
     if let Some(stem) = strip_trailing_comma_article(s) {
@@ -242,13 +242,80 @@ fn drop_articles(s: &str) -> String {
     s.to_string()
 }
 
-fn strip_leading_article(s: &str) -> Option<&str> {
+/// Internal helper used by [`drop_articles`]. Only matches the
+/// space-suffix form (`"the "`, `"a "`, `"an "`); a bare leading article
+/// (`"the"` with no trailing content) is preserved on purpose so that
+/// `to_identity_match_form("The")` returns `"the"` rather than `""`.
+///
+/// The public, broader [`strip_leading_article`] (used by Python callers via
+/// the PyO3 binding) does strip bare articles to the empty string. Keep these
+/// two helpers separate so a Python parity expectation cannot inadvertently
+/// retune the identity-match pipeline.
+fn strip_leading_article_with_space_suffix(s: &str) -> Option<&str> {
     for article in ["the ", "a ", "an "] {
         if let Some(rest) = s.strip_prefix(article) {
             return Some(rest);
         }
     }
     None
+}
+
+/// Strip a leading article (`the`, `a`, `an`) from a lowercased + trimmed
+/// string. Returns the input unchanged when there is no leading article.
+///
+/// The article must be followed by ASCII whitespace OR end-of-string. This
+/// mirrors the Python `^(the|a|an)(\s+|$)` regex used by
+/// `library-metadata-lookup`'s reconciler and FTS5 prefix-lookup paths so the
+/// cross-cache identity layer and the Python consumers see byte-identical
+/// outputs (E3 normalization charter; epic [WXYC/wxyc-etl#73]).
+///
+/// Trailing whitespace after the article is consumed in full
+/// (e.g. `"the  beatles"` → `"beatles"`), matching `\s+` greediness. Only the
+/// first matching article is stripped; `"the the"` → `"the"`.
+///
+/// # Contract
+///
+/// - Input is assumed lowercased and trimmed (matches `to_match_form` output
+///   or `str.lower()` on a pre-trimmed user-typed name). Casing is **not**
+///   normalized inside; uppercased articles like `"The"` are a no-op.
+/// - The article list is intentionally English-only. Plan §3.3.2 reserves
+///   Romance-language articles (`le`, `la`, `los`, `las`) for a future
+///   extension; when those land here, every consumer of the PyO3 binding
+///   inherits them automatically.
+///
+/// # Relationship to `to_identity_match_form`
+///
+/// This function is the standalone, public counterpart to the step-5 logic
+/// inside [`to_identity_match_form`]. It is **strictly more aggressive** for
+/// bare-article inputs: `strip_leading_article("the")` → `""`, whereas
+/// `to_identity_match_form("The")` → `"the"`. The latter deliberately
+/// preserves bare articles to keep the identity-match fallback ladder from
+/// collapsing a stem to empty.
+///
+/// # Examples
+///
+/// ```
+/// use wxyc_etl::text::strip_leading_article;
+///
+/// assert_eq!(strip_leading_article("the beatles"), "beatles");
+/// assert_eq!(strip_leading_article("a tribe called quest"), "tribe called quest");
+/// assert_eq!(strip_leading_article("an albatross"), "albatross");
+/// assert_eq!(strip_leading_article("the"), "");
+/// assert_eq!(strip_leading_article("theater"), "theater");
+/// assert_eq!(strip_leading_article("stereolab"), "stereolab");
+/// ```
+pub fn strip_leading_article(s: &str) -> &str {
+    for article in ["the", "a", "an"] {
+        if let Some(rest) = s.strip_prefix(article) {
+            if rest.is_empty() {
+                return rest;
+            }
+            if rest.starts_with(|c: char| c.is_ascii_whitespace()) {
+                return rest.trim_start_matches(|c: char| c.is_ascii_whitespace());
+            }
+        }
+    }
+    s
 }
 
 fn strip_trailing_comma_article(s: &str) -> Option<&str> {
@@ -395,6 +462,95 @@ mod tests {
             to_identity_match_form("The Foo Fighters (1995)"),
             "foo fighters"
         );
+    }
+
+    // --- public strip_leading_article (PyO3-exposed; e3-normalization#133) ---
+
+    #[test]
+    fn pub_strip_drops_the_prefix() {
+        assert_eq!(strip_leading_article("the beatles"), "beatles");
+    }
+
+    #[test]
+    fn pub_strip_drops_a_prefix() {
+        assert_eq!(
+            strip_leading_article("a tribe called quest"),
+            "tribe called quest"
+        );
+    }
+
+    #[test]
+    fn pub_strip_drops_an_prefix() {
+        assert_eq!(strip_leading_article("an albatross"), "albatross");
+    }
+
+    #[test]
+    fn pub_strip_drops_bare_the_to_empty() {
+        // Bare article (EOS match) — diverges from drop_articles, which preserves
+        // bare articles in identity-matching context.
+        assert_eq!(strip_leading_article("the"), "");
+    }
+
+    #[test]
+    fn pub_strip_drops_bare_a_to_empty() {
+        assert_eq!(strip_leading_article("a"), "");
+    }
+
+    #[test]
+    fn pub_strip_drops_bare_an_to_empty() {
+        assert_eq!(strip_leading_article("an"), "");
+    }
+
+    #[test]
+    fn pub_strip_no_op_on_prefix_substring() {
+        // No word boundary after the article.
+        assert_eq!(strip_leading_article("theater"), "theater");
+        assert_eq!(
+            strip_leading_article("thee silver mt zion"),
+            "thee silver mt zion"
+        );
+        assert_eq!(strip_leading_article("animal"), "animal");
+        assert_eq!(strip_leading_article("apple"), "apple");
+    }
+
+    #[test]
+    fn pub_strip_no_op_on_no_article() {
+        assert_eq!(strip_leading_article("stereolab"), "stereolab");
+        assert_eq!(strip_leading_article("juana molina"), "juana molina");
+    }
+
+    #[test]
+    fn pub_strip_no_op_on_empty() {
+        assert_eq!(strip_leading_article(""), "");
+    }
+
+    #[test]
+    fn pub_strip_consumes_multiple_spaces_after_article() {
+        // Matches Python `\s+` semantics — consume all ASCII whitespace after
+        // the article boundary.
+        assert_eq!(strip_leading_article("the  beatles"), "beatles");
+        assert_eq!(strip_leading_article("a\ttribe"), "tribe");
+    }
+
+    #[test]
+    fn pub_strip_consumes_only_first_article() {
+        // `the the` → strip one leading `the ` → `the`.
+        assert_eq!(strip_leading_article("the the"), "the");
+    }
+
+    #[test]
+    fn pub_strip_idempotent_after_one_strip() {
+        // Two calls: first strips, second is a no-op (since "beatles" has no article).
+        let once = strip_leading_article("the beatles");
+        let twice = strip_leading_article(once);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn pub_strip_preserves_input_when_not_lowercased() {
+        // Documented Python contract: input is assumed lowercased + trimmed.
+        // The helper does not normalize; an uppercased article is a no-op.
+        assert_eq!(strip_leading_article("The Beatles"), "The Beatles");
     }
 
     // --- inherited from to_match_form: sigma + diacritics ---

--- a/wxyc-etl/src/text/identity.rs
+++ b/wxyc-etl/src/text/identity.rs
@@ -263,24 +263,24 @@ fn strip_leading_article_with_space_suffix(s: &str) -> Option<&str> {
 /// Strip a leading article (`the`, `a`, `an`) from a lowercased + trimmed
 /// string. Returns the input unchanged when there is no leading article.
 ///
-/// The article must be followed by Unicode whitespace OR end-of-string,
+/// The article must be followed by whitespace OR end-of-string, byte-for-byte
 /// matching the Python `^(the|a|an)(\s+|$)` regex used by
-/// `library-metadata-lookup`'s reconciler and FTS5 prefix-lookup paths so the
-/// cross-cache identity layer and the Python consumers produce byte-identical
-/// outputs (E3 normalization charter; epic [WXYC/wxyc-etl#73]). "Unicode
-/// whitespace" here means [`char::is_whitespace`], which matches the same
-/// `White_Space` property that Python 3's default `\s` matches — i.e. ASCII
-/// space, TAB, NBSP (U+00A0), OGHAM SPACE (U+1680), LINE / PARAGRAPH
-/// SEPARATOR (U+2028 / U+2029), and the other [`Pattern_White_Space`][zs]
-/// codepoints. Step 7 of `to_match_form` preserves non-ASCII whitespace, so
-/// these codepoints can appear in real artist names (e.g. pasted from
-/// Wikipedia) and must round-trip the same on both sides.
+/// `library-metadata-lookup`'s reconciler and FTS5 prefix-lookup paths
+/// (E3 normalization charter; epic [WXYC/wxyc-etl#73]).
+///
+/// "Whitespace" here is the exact codepoint set CPython's `re` engine treats
+/// as `\s` for `str` patterns: the Unicode `White_Space` property (matched by
+/// [`char::is_whitespace`]) plus the four ASCII information separators
+/// U+001C..=U+001F (FS, GS, RS, US — a CPython quirk that pre-dates Unicode
+/// `White_Space` and survives in `Py_UNICODE_ISSPACE`). `to_match_form` does
+/// not strip these — NBSP and the other Zs codepoints with NFKC
+/// decompositions to ASCII space are folded away by step 2, but OGHAM SPACE
+/// (U+1680), LINE / PARAGRAPH SEPARATOR (U+2028 / U+2029), and the info
+/// separators round-trip unchanged and must hash identically on both sides.
 ///
 /// Trailing whitespace after the article is consumed in full
 /// (e.g. `"the  beatles"` → `"beatles"`), matching `\s+` greediness. Only the
 /// first matching article is stripped; `"the the"` → `"the"`.
-///
-/// [zs]: https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt
 ///
 /// # Contract
 ///
@@ -319,12 +319,17 @@ pub fn strip_leading_article(s: &str) -> &str {
             if rest.is_empty() {
                 return rest;
             }
-            if rest.starts_with(|c: char| c.is_whitespace()) {
-                return rest.trim_start_matches(|c: char| c.is_whitespace());
+            if rest.starts_with(is_python_whitespace) {
+                return rest.trim_start_matches(is_python_whitespace);
             }
         }
     }
     s
+}
+
+/// CPython's `\s` for `str` patterns: Unicode `White_Space` ∪ U+001C..=U+001F.
+fn is_python_whitespace(c: char) -> bool {
+    c.is_whitespace() || matches!(c, '\u{1C}'..='\u{1F}')
 }
 
 fn strip_trailing_comma_article(s: &str) -> Option<&str> {
@@ -548,14 +553,29 @@ mod tests {
     }
 
     #[test]
-    fn pub_strip_matches_unicode_whitespace() {
-        // Mirrors Python `\s+` for the full `White_Space` codepoint set. These
-        // codepoints survive `to_match_form` (which only collapses ASCII
-        // U+0020), so a cross-cache caller can hand them off intact.
+    fn pub_strip_matches_python_re_whitespace() {
+        // Mirrors CPython's `\s` for str patterns: White_Space ∪ U+001C..=U+001F.
+        // NBSP folds away under NFKC inside `to_match_form` and never reaches
+        // here from that path, but the standalone helper takes pre-normalized
+        // input from other paths too — pin it here so the contract is explicit.
         assert_eq!(strip_leading_article("the\u{a0}beatles"), "beatles");
         assert_eq!(strip_leading_article("the\u{1680}beatles"), "beatles");
         assert_eq!(strip_leading_article("the\u{2028}beatles"), "beatles");
         assert_eq!(strip_leading_article("the\u{2029}beatles"), "beatles");
+        // The four ASCII info separators are CPython's historical `\s` quirk.
+        assert_eq!(strip_leading_article("the\u{1c}beatles"), "beatles");
+        assert_eq!(strip_leading_article("the\u{1d}beatles"), "beatles");
+        assert_eq!(strip_leading_article("the\u{1e}beatles"), "beatles");
+        assert_eq!(strip_leading_article("the\u{1f}beatles"), "beatles");
+    }
+
+    #[test]
+    fn pub_strip_consumes_mixed_whitespace_run() {
+        // `\s+` greediness across heterogeneous codepoints.
+        assert_eq!(
+            strip_leading_article("the \u{a0}\t\u{1680}beatles"),
+            "beatles"
+        );
     }
 
     #[test]

--- a/wxyc-etl/src/text/identity.rs
+++ b/wxyc-etl/src/text/identity.rs
@@ -263,15 +263,24 @@ fn strip_leading_article_with_space_suffix(s: &str) -> Option<&str> {
 /// Strip a leading article (`the`, `a`, `an`) from a lowercased + trimmed
 /// string. Returns the input unchanged when there is no leading article.
 ///
-/// The article must be followed by ASCII whitespace OR end-of-string. This
-/// mirrors the Python `^(the|a|an)(\s+|$)` regex used by
+/// The article must be followed by Unicode whitespace OR end-of-string,
+/// matching the Python `^(the|a|an)(\s+|$)` regex used by
 /// `library-metadata-lookup`'s reconciler and FTS5 prefix-lookup paths so the
-/// cross-cache identity layer and the Python consumers see byte-identical
-/// outputs (E3 normalization charter; epic [WXYC/wxyc-etl#73]).
+/// cross-cache identity layer and the Python consumers produce byte-identical
+/// outputs (E3 normalization charter; epic [WXYC/wxyc-etl#73]). "Unicode
+/// whitespace" here means [`char::is_whitespace`], which matches the same
+/// `White_Space` property that Python 3's default `\s` matches — i.e. ASCII
+/// space, TAB, NBSP (U+00A0), OGHAM SPACE (U+1680), LINE / PARAGRAPH
+/// SEPARATOR (U+2028 / U+2029), and the other [`Pattern_White_Space`][zs]
+/// codepoints. Step 7 of `to_match_form` preserves non-ASCII whitespace, so
+/// these codepoints can appear in real artist names (e.g. pasted from
+/// Wikipedia) and must round-trip the same on both sides.
 ///
 /// Trailing whitespace after the article is consumed in full
 /// (e.g. `"the  beatles"` → `"beatles"`), matching `\s+` greediness. Only the
 /// first matching article is stripped; `"the the"` → `"the"`.
+///
+/// [zs]: https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt
 ///
 /// # Contract
 ///
@@ -310,8 +319,8 @@ pub fn strip_leading_article(s: &str) -> &str {
             if rest.is_empty() {
                 return rest;
             }
-            if rest.starts_with(|c: char| c.is_ascii_whitespace()) {
-                return rest.trim_start_matches(|c: char| c.is_ascii_whitespace());
+            if rest.starts_with(|c: char| c.is_whitespace()) {
+                return rest.trim_start_matches(|c: char| c.is_whitespace());
             }
         }
     }
@@ -539,11 +548,14 @@ mod tests {
     }
 
     #[test]
-    fn pub_strip_idempotent_after_one_strip() {
-        // Two calls: first strips, second is a no-op (since "beatles" has no article).
-        let once = strip_leading_article("the beatles");
-        let twice = strip_leading_article(once);
-        assert_eq!(once, twice);
+    fn pub_strip_matches_unicode_whitespace() {
+        // Mirrors Python `\s+` for the full `White_Space` codepoint set. These
+        // codepoints survive `to_match_form` (which only collapses ASCII
+        // U+0020), so a cross-cache caller can hand them off intact.
+        assert_eq!(strip_leading_article("the\u{a0}beatles"), "beatles");
+        assert_eq!(strip_leading_article("the\u{1680}beatles"), "beatles");
+        assert_eq!(strip_leading_article("the\u{2028}beatles"), "beatles");
+        assert_eq!(strip_leading_article("the\u{2029}beatles"), "beatles");
     }
 
     #[test]

--- a/wxyc-etl/src/text/mod.rs
+++ b/wxyc-etl/src/text/mod.rs
@@ -25,7 +25,7 @@ pub use compilation::is_compilation_artist;
 pub use filter::{ArtistFilter, TitleFilter};
 pub use forms::{to_ascii_form, to_match_form, to_storage_form};
 pub use identity::{
-    to_identity_match_form, to_identity_match_form_title,
+    strip_leading_article, to_identity_match_form, to_identity_match_form_title,
     to_identity_match_form_with_disambiguator_strip, to_identity_match_form_with_punctuation,
 };
 pub use mojibake::fix_mojibake;

--- a/wxyc-etl/tests/fixtures/identity_normalization_cases.csv
+++ b/wxyc-etl/tests/fixtures/identity_normalization_cases.csv
@@ -158,7 +158,7 @@ thee silver mt zion,thee silver mt zion,article,leading-article-strip,no word bo
 animal,animal,article,leading-article-strip,prefix substring negative
 stereolab,stereolab,article,leading-article-strip,no article negative
 the the,the,article,leading-article-strip,only first article stripped
-the  beatles,beatles,article,leading-article-strip,multiple spaces collapsed
+the  beatles,beatles,article,leading-article-strip,whitespace run after article consumed in full
 juana molina,juana molina,article,leading-article-strip,canonical WXYC artist negative
 the beatles,beatles,article,leading-article-strip,NBSP after article (U+00A0)
 the beatles,beatles,article,leading-article-strip,OGHAM SPACE after article (U+1680)

--- a/wxyc-etl/tests/fixtures/identity_normalization_cases.csv
+++ b/wxyc-etl/tests/fixtures/identity_normalization_cases.csv
@@ -160,6 +160,10 @@ stereolab,stereolab,article,leading-article-strip,no article negative
 the the,the,article,leading-article-strip,only first article stripped
 the  beatles,beatles,article,leading-article-strip,multiple spaces collapsed
 juana molina,juana molina,article,leading-article-strip,canonical WXYC artist negative
+the beatles,beatles,article,leading-article-strip,NBSP after article (U+00A0)
+the beatles,beatles,article,leading-article-strip,OGHAM SPACE after article (U+1680)
+the beatles,beatles,article,leading-article-strip,LINE SEPARATOR after article (U+2028)
+the beatles,beatles,article,leading-article-strip,PARAGRAPH SEPARATOR after article (U+2029)
 
 # ===== punct (50) — to_identity_match_form_with_punctuation =====
 M.I.A.,m i a,punct,punct,classic dotted abbreviation

--- a/wxyc-etl/tests/fixtures/identity_normalization_cases.csv
+++ b/wxyc-etl/tests/fixtures/identity_normalization_cases.csv
@@ -141,6 +141,26 @@ Andy Human and the Reptoids,andy human and the reptoids,base,leading-article,art
 Aphex Twin,aphex twin,base,leading-article,no article negative
 "Stereolab, The",stereolab,base,leading-article,Discogs comma form
 
+# ===== leading-article-strip (10+) — wxyc_etl.text.strip_leading_article =====
+# Public PyO3-exposed helper (e3-normalization#133). Inputs are already
+# lowercased + trimmed by the caller; this variant exercises the standalone
+# article stripper, not the full to_identity_match_form pipeline. Diverges
+# from drop_articles on bare-article inputs: `the` → `""` here, `to_identity_match_form("The")` → `"the"`.
+the beatles,beatles,article,leading-article-strip,
+a tribe called quest,tribe called quest,article,leading-article-strip,
+an albatross,albatross,article,leading-article-strip,
+the microphones,microphones,article,leading-article-strip,
+the,,article,leading-article-strip,bare article EOS match
+a,,article,leading-article-strip,bare article EOS match
+an,,article,leading-article-strip,bare article EOS match
+theater,theater,article,leading-article-strip,prefix substring negative
+thee silver mt zion,thee silver mt zion,article,leading-article-strip,no word boundary after article
+animal,animal,article,leading-article-strip,prefix substring negative
+stereolab,stereolab,article,leading-article-strip,no article negative
+the the,the,article,leading-article-strip,only first article stripped
+the  beatles,beatles,article,leading-article-strip,multiple spaces collapsed
+juana molina,juana molina,article,leading-article-strip,canonical WXYC artist negative
+
 # ===== punct (50) — to_identity_match_form_with_punctuation =====
 M.I.A.,m i a,punct,punct,classic dotted abbreviation
 R.E.M.,r e m,punct,punct,

--- a/wxyc-etl/tests/fixtures/identity_normalization_cases.csv
+++ b/wxyc-etl/tests/fixtures/identity_normalization_cases.csv
@@ -164,6 +164,8 @@ the beatles,beatles,article,leading-article-strip,NBSP after article (U+00A0)
 the beatles,beatles,article,leading-article-strip,OGHAM SPACE after article (U+1680)
 the beatles,beatles,article,leading-article-strip,LINE SEPARATOR after article (U+2028)
 the beatles,beatles,article,leading-article-strip,PARAGRAPH SEPARATOR after article (U+2029)
+thebeatles,beatles,article,leading-article-strip,FILE SEPARATOR after article (U+001C — CPython \s quirk)
+the   beatles,beatles,article,leading-article-strip,mixed-codepoint whitespace run
 
 # ===== punct (50) — to_identity_match_form_with_punctuation =====
 M.I.A.,m i a,punct,punct,classic dotted abbreviation

--- a/wxyc-etl/tests/identity_normalization_parity.rs
+++ b/wxyc-etl/tests/identity_normalization_parity.rs
@@ -8,7 +8,7 @@
 //!
 //! Format:
 //!   input,expected,variant,category,notes
-//!   variant ∈ {base, title, punct, disamb}
+//!   variant ∈ {base, title, punct, disamb, article}
 //!
 //! Lines starting with `#` are comments. Empty lines are skipped. Quoted
 //! fields use the same minimal CSV convention as the WX-1 charset-torture
@@ -24,7 +24,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use wxyc_etl::text::{
-    to_identity_match_form, to_identity_match_form_title,
+    strip_leading_article, to_identity_match_form, to_identity_match_form_title,
     to_identity_match_form_with_disambiguator_strip, to_identity_match_form_with_punctuation,
 };
 
@@ -114,6 +114,7 @@ fn apply(variant: &str, input: &str) -> String {
         "title" => to_identity_match_form_title(input),
         "punct" => to_identity_match_form_with_punctuation(input),
         "disamb" => to_identity_match_form_with_disambiguator_strip(input),
+        "article" => strip_leading_article(input).to_string(),
         other => panic!("unknown variant {other:?}"),
     }
 }
@@ -158,6 +159,7 @@ fn fixture_meets_categorical_coverage_minimums() {
         ("trailing-parens-artist", 50),
         ("trailing-parens-title", 50),
         ("leading-article", 25),
+        ("leading-article-strip", 10),
         ("punct", 50),
         ("disamb", 50),
         ("disamb-title-negative", 25),

--- a/wxyc-etl/tests/postgres_parity_test.rs
+++ b/wxyc-etl/tests/postgres_parity_test.rs
@@ -172,6 +172,13 @@ fn postgres_parity_matches_rust_for_every_fixture_row() {
 
     let mut failures: Vec<String> = Vec::new();
     for row in &rows {
+        // The `article` variant exercises the standalone `strip_leading_article`
+        // helper exposed to Python via PyO3. It has no SQL counterpart by design
+        // — PG-side article stripping happens inside `wxyc_identity_match_artist`
+        // (step 5), not as a standalone function — so skip those rows here.
+        if row.variant == "article" {
+            continue;
+        }
         // Sanity: the committed expected matches the Rust function output.
         // (Already covered by identity_normalization_parity, but cheap to repeat
         // here so PG failures are not confused with Rust drift.)


### PR DESCRIPTION
Closes #133.

## Summary

- Promotes `strip_leading_article` from a private helper inside `drop_articles` to a top-level public function with its own PyO3 binding at `wxyc_etl.text.strip_leading_article`.
- Preserves `to_identity_match_form` behavior byte-for-byte by keeping the original space-suffix-only logic under a separate name (`strip_leading_article_with_space_suffix`). The new public helper has the broader contract Python callers want: bare-article → `""`, `^(the|a|an)(\s+|$)` boundary, returns input unchanged on no-match.
- Extends the identity-normalization parity matrix: new `article` variant in `identity_normalization_parity.rs`, new `leading-article-strip` category with 14 rows in `identity_normalization_cases.csv`, and a coverage floor of 10 for the new category.

## Why two helpers

The existing private helper is load-bearing for the two-stage strip inside `drop_articles` (leading-article-form + trailing-comma-form). Its space-suffix-only matcher (`"the "` / `"a "` / `"an "`) deliberately preserves bare articles so `to_identity_match_form("The")` returns `"the"` rather than `""` — collapsing identity-match stems to empty would break the fallback ladder. The new public helper has different consumers (`library-metadata-lookup`'s `orchestrator.py` and `library/db.py`) that expect EOS-handling article stripping.

Separating the two helpers makes it impossible for a future Python-side parity expectation to inadvertently retune the identity-match pipeline. Doc comments on both call out the divergence.

## Acceptance criteria (issue #133)

- [x] `wxyc_etl.text.strip_leading_article` callable from Python with the LML-side regex semantics (bare → empty, leading + word → word, no article → unchanged, `thee silver mt zion` not stripped).
- [x] Parity-test row count for article cases grows by ≥10 (added 14 under the new `leading-article-strip` category).
- [ ] Released to PyPI in the next minor bump (will follow on merge — release workflow already wired in `.github/workflows/release.yml`).
- [ ] Follow-up LML PR flips both Python call sites + deletes `core/text.py`. Filed separately after this lands.

## Test plan

- [x] `cargo test --workspace` — all 469 unit tests + parity matrix green.
- [x] `cargo fmt --check` + CI's clippy invocation clean.
- [x] `maturin develop` from `wxyc-etl-python/` produces a working wheel.
- [x] `from wxyc_etl.text import strip_leading_article` smoke-tested on 13 cases including `None → ""`, bare articles, prefix-substring negatives.
- [x] Python suite: 433 passed, 1 skipped.