### PR TITLE
chore: bump workspace version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3133,7 +3133,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wxyc-etl"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "wxyc-etl-python"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,6 @@ members = ["wxyc-etl", "wxyc-etl-python"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bumps `[workspace.package].version` from `0.5.0` to `0.6.0`. `Cargo.lock` regenerated.

## Release contents

Since `v0.5.0`, `main` picked up:

- `feat(text)`: expose `strip_leading_article` as a public PyO3 binding (#133, [PR #134](https://github.com/WXYC/wxyc-etl/pull/134)) — drops `{the, a, an}` when followed by Python-`\s` whitespace (Unicode `White_Space` ∪ U+001C..=U+001F). Unblocks LML's follow-up to delete `core/text.py` and stop maintaining a local copy.
- `docs(claude-md)`: extract topic guides, slim CLAUDE.md to router (#131).

No breaking changes; pure additions. Minor bump per [`docs/releases.md`](https://github.com/WXYC/wxyc-etl/blob/main/docs/releases.md).

## Post-merge

1. `git tag v0.6.0` on `main` HEAD and `git push origin v0.6.0` to fire [`release.yml`](https://github.com/WXYC/wxyc-etl/blob/main/.github/workflows/release.yml) (publishes `wxyc-etl` to crates.io + PyPI; rebuilds `ghcr.io/wxyc/wxyc-postgres:pg17,pg16` with the matching `:pgN-v0.6.0` pin).
2. Follow-up LML PR pins `wxyc-etl>=0.6.0,<0.7.0` and flips `lookup/orchestrator.py:_strip_leading_article` + `library/db.py:_strip_leading_artist_article` to `from wxyc_etl.text import strip_leading_article`, deleting `core/text.py`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets` with CI flag set
- [x] `cargo test --workspace`
- [ ] After merge: workflow_dispatch `release.yml` with `dry_run: true` to rehearse the publish path before tagging.