### PR TITLE
Add to_pg_text_form boundary-safety helper

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ The Python crate lives in the same workspace so it shares the lockfile with the 
 | Module | Purpose |
 |---|---|
 | `text` | WX-2 charter forms (`to_storage_form`, `to_match_form`, `to_ascii_form`) and the cross-cache-identity layer (`to_identity_match_form` + variants in `text::identity`); compilation detection (`is_compilation_artist`); multi-artist split with optional contextual hints (`split_artist_name`, `split_artist_name_contextual`); batch variants in `text::batch`; file-backed `ArtistFilter` / `TitleFilter` in `text::filter`. |
-| `pg` | `BatchCopier` and friends for `COPY TEXT` bulk loading, FK-ordered flush, dedup tracking, admin helpers (`SET UNLOGGED` / `SET LOGGED`). Backed by sync `postgres` crate. |
+| `pg` | `BatchCopier` and friends for `COPY TEXT` bulk loading, FK-ordered flush, dedup tracking, admin helpers (`SET UNLOGGED` / `SET LOGGED`), and TEXT-column boundary-safety helpers (`to_pg_text_form` — strips U+0000 per WX-3.B policy). Backed by sync `postgres` crate. |
 | `pipeline` | Generic scanner → rayon → writer parallel framework (`PipelineRunner`, `PipelineOutput` trait). Used by the streaming Rust filters to pipe huge dumps through worker pools without building intermediate vectors. |
 | `csv_writer` | `MultiCsvWriter` — write to many CSVs in parallel from a single producer. |
 | `sqlite` | SQLite helpers: FTS5 setup, performance pragmas, batch insert wrappers. |

--- a/wxyc-etl-python/python/wxyc_etl/__init__.py
+++ b/wxyc-etl-python/python/wxyc_etl/__init__.py
@@ -1,7 +1,7 @@
 """Python bindings for the wxyc-etl Rust crate, plus pure-Python helpers.
 
 The Rust extension lives at :mod:`wxyc_etl._native`; its submodules
-(``text``, ``parser``, ``state``, ``import_utils``, ``schema``, ``fuzzy``) are
+(``text``, ``parser``, ``pg``, ``state``, ``import_utils``, ``schema``, ``fuzzy``) are
 re-exported here so callers can use ``from wxyc_etl import text`` and
 ``from wxyc_etl.text import to_match_form`` interchangeably.
 
@@ -13,6 +13,7 @@ from ._native import (
     fuzzy,
     import_utils,
     parser,
+    pg,
     schema,
     state,
     text,
@@ -23,6 +24,7 @@ __all__ = [
     "import_utils",
     "logger",
     "parser",
+    "pg",
     "schema",
     "state",
     "text",

--- a/wxyc-etl-python/src/lib.rs
+++ b/wxyc-etl-python/src/lib.rs
@@ -4,6 +4,7 @@ use pyo3::types::PyModuleMethods;
 mod fuzzy;
 mod import_utils;
 mod parser;
+mod pg;
 mod schema;
 mod state;
 mod text;
@@ -32,6 +33,7 @@ fn register_submodule(
 fn _native(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     register_submodule(py, m, "text", text::register)?;
     register_submodule(py, m, "parser", parser::register)?;
+    register_submodule(py, m, "pg", pg::register)?;
     register_submodule(py, m, "state", state::register)?;
     register_submodule(py, m, "import_utils", import_utils::register)?;
     register_submodule(py, m, "schema", schema::register)?;

--- a/wxyc-etl-python/src/pg.rs
+++ b/wxyc-etl-python/src/pg.rs
@@ -1,0 +1,30 @@
+use pyo3::prelude::*;
+
+/// Register pg submodule functions.
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(to_pg_text_form, m)?)?;
+    m.add_function(wrap_pyfunction!(batch_to_pg_text_form, m)?)?;
+    Ok(())
+}
+
+/// Make `s` acceptable for storage in a PostgreSQL TEXT column.
+///
+/// Strips U+0000 (NUL) bytes, which the SQL standard forbids in character
+/// types. Accepts None (returns "") so Python callers don't need to guard
+/// NULL values from DB columns or optional API fields.
+///
+/// See WX-3.B / WXYC/docs#18 for the strip-at-boundary policy.
+#[pyfunction]
+fn to_pg_text_form(s: Option<&str>) -> String {
+    s.map(|s| wxyc_etl::pg::to_pg_text_form(s).into_owned())
+        .unwrap_or_default()
+}
+
+/// Apply [`to_pg_text_form`] to each input in one cross-FFI call.
+#[pyfunction]
+fn batch_to_pg_text_form(items: Vec<String>) -> Vec<String> {
+    items
+        .iter()
+        .map(|s| wxyc_etl::pg::to_pg_text_form(s).into_owned())
+        .collect()
+}

--- a/wxyc-etl-python/tests/test_import.py
+++ b/wxyc-etl-python/tests/test_import.py
@@ -6,6 +6,7 @@ def test_import_wxyc_etl():
 
     assert hasattr(wxyc_etl, "text")
     assert hasattr(wxyc_etl, "parser")
+    assert hasattr(wxyc_etl, "pg")
     assert hasattr(wxyc_etl, "state")
     assert hasattr(wxyc_etl, "import_utils")
     assert hasattr(wxyc_etl, "schema")
@@ -29,6 +30,13 @@ def test_parser_submodule_functions():
     assert callable(parser.load_table_rows)
     assert callable(parser.iter_table_rows)
     assert callable(parser.parse_sql_values)
+
+
+def test_pg_submodule_functions():
+    from wxyc_etl import pg
+
+    assert callable(pg.to_pg_text_form)
+    assert callable(pg.batch_to_pg_text_form)
 
 
 def test_state_submodule_class():

--- a/wxyc-etl-python/tests/test_pg.py
+++ b/wxyc-etl-python/tests/test_pg.py
@@ -1,0 +1,61 @@
+"""Python parity for wxyc_etl.pg boundary-safety helpers.
+
+These functions are about PostgreSQL TEXT transport safety, NOT normalization
+— they make a string acceptable for storage without changing its meaning.
+See `wxyc-etl/src/pg/text.rs` for the Rust contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+from wxyc_etl import pg
+
+
+# --- to_pg_text_form -----------------------------------------------------
+
+@pytest.mark.parametrize(
+    "input_str,expected",
+    [
+        ("", ""),
+        ("Stereolab", "Stereolab"),
+        ("Nilüfer Yanya", "Nilüfer Yanya"),
+        ("Csillagrablók", "Csillagrablók"),
+        ("Stereo\0lab", "Stereolab"),
+        ("\0Autechre", "Autechre"),
+        ("Cat Power\0", "Cat Power"),
+        ("\0\0\0", ""),
+        ("foo\0bar\0baz", "foobarbaz"),
+        ("Csillagrabl\0ók", "Csillagrablók"),
+        ("line1\tcol\nline2\x0bvt", "line1\tcol\nline2\x0bvt"),
+    ],
+)
+def test_to_pg_text_form(input_str, expected):
+    assert pg.to_pg_text_form(input_str) == expected
+
+
+def test_to_pg_text_form_accepts_none():
+    """Mirrors the charter-form Option<&str> -> "" contract."""
+    assert pg.to_pg_text_form(None) == ""
+
+
+def test_to_pg_text_form_idempotent():
+    once = pg.to_pg_text_form("foo\0bar\0baz")
+    twice = pg.to_pg_text_form(once)
+    assert once == twice == "foobarbaz"
+
+
+# --- batch_to_pg_text_form -----------------------------------------------
+
+def test_batch_to_pg_text_form_matches_singles():
+    inputs = ["Stereolab", "Cat\0Power", "Nilüfer Yanya", "\0Autechre\0"]
+    expected = [pg.to_pg_text_form(s) for s in inputs]
+    assert pg.batch_to_pg_text_form(inputs) == expected
+
+
+def test_batch_to_pg_text_form_empty():
+    assert pg.batch_to_pg_text_form([]) == []
+
+
+def test_batch_to_pg_text_form_all_clean():
+    inputs = ["Juana Molina", "Sessa", "Hermanos Gutiérrez"]
+    assert pg.batch_to_pg_text_form(inputs) == inputs

--- a/wxyc-etl/src/pg/mod.rs
+++ b/wxyc-etl/src/pg/mod.rs
@@ -1,19 +1,20 @@
 //! PostgreSQL bulk loading utilities.
 //!
 //! Provides COPY TEXT escaping, row formatting, buffered batch writing,
-//! deduplication tracking, and administrative operations for PostgreSQL
-//! bulk imports.
+//! deduplication tracking, administrative operations, and boundary-safety
+//! helpers for PostgreSQL bulk imports.
 //!
 //! # Quick start
 //!
 //! ```ignore
-//! use wxyc_etl::pg::{escape_copy_text, write_copy_row, write_copy_int, BatchCopier, DedupSet, extract_year};
+//! use wxyc_etl::pg::{escape_copy_text, write_copy_row, write_copy_int, BatchCopier, DedupSet, extract_year, to_pg_text_form};
 //! ```
 
 pub mod admin;
 pub mod batch;
 pub mod copy;
 pub mod dedup;
+pub mod text;
 
 // Re-export commonly used items at the pg module level.
 pub use admin::{set_tables_logged, set_tables_unlogged, vacuum_full};
@@ -23,3 +24,4 @@ pub use copy::{
     pick_artwork_url, write_copy_int, write_copy_row, ImageRef,
 };
 pub use dedup::{ArtistDedup, DedupSet, LabelDedup, TrackArtistDedup};
+pub use text::to_pg_text_form;

--- a/wxyc-etl/src/pg/text.rs
+++ b/wxyc-etl/src/pg/text.rs
@@ -1,0 +1,122 @@
+//! Boundary-safety helpers for PostgreSQL TEXT columns.
+//!
+//! These are about *transport*, not *normalization* — they make a string
+//! *acceptable* to a downstream sink without changing its meaning. The
+//! conceptual line vs `text::forms` (storage/match/ascii) is load-bearing
+//! and intentionally guarded: don't move boundary-safety helpers into
+//! `text::forms`, and don't import normalization into this module.
+
+use std::borrow::Cow;
+
+/// Make `s` acceptable for storage in a PostgreSQL TEXT column.
+///
+/// Today this strips U+0000 (NUL), which the SQL standard forbids in
+/// character types — Postgres rejects rows containing it with
+/// `invalid byte sequence for encoding`. Returns `Cow::Borrowed` when
+/// the input is already acceptable so the common case never allocates.
+///
+/// Per the WX-3.B policy ratified on [WXYC/docs#18](https://github.com/WXYC/docs/issues/18),
+/// every PG TEXT write boundary calls this helper. U+0000 in metadata is
+/// always corruption, never intent.
+///
+/// Idempotent: `to_pg_text_form(to_pg_text_form(s)) == to_pg_text_form(s)`.
+pub fn to_pg_text_form(s: &str) -> Cow<'_, str> {
+    if s.contains('\0') {
+        Cow::Owned(s.replace('\0', ""))
+    } else {
+        Cow::Borrowed(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_string_is_borrowed() {
+        let out = to_pg_text_form("");
+        assert_eq!(out, "");
+        assert!(matches!(out, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn no_nul_returns_borrowed() {
+        let input = "Nilüfer Yanya";
+        let out = to_pg_text_form(input);
+        assert_eq!(out, input);
+        assert!(matches!(out, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn single_nul_returns_owned_with_nul_stripped() {
+        let out = to_pg_text_form("Stereo\0lab");
+        assert_eq!(out, "Stereolab");
+        assert!(matches!(out, Cow::Owned(_)));
+    }
+
+    #[test]
+    fn leading_nul_stripped() {
+        let out = to_pg_text_form("\0Autechre");
+        assert_eq!(out, "Autechre");
+        assert!(matches!(out, Cow::Owned(_)));
+    }
+
+    #[test]
+    fn trailing_nul_stripped() {
+        let out = to_pg_text_form("Cat Power\0");
+        assert_eq!(out, "Cat Power");
+        assert!(matches!(out, Cow::Owned(_)));
+    }
+
+    #[test]
+    fn all_nul_collapses_to_empty() {
+        let out = to_pg_text_form("\0\0\0");
+        assert_eq!(out, "");
+        assert!(matches!(out, Cow::Owned(_)));
+    }
+
+    #[test]
+    fn idempotent_on_clean_input() {
+        let input = "Hermanos Gutiérrez";
+        let once = to_pg_text_form(input).into_owned();
+        let twice = to_pg_text_form(&once).into_owned();
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn idempotent_on_nul_bearing_input() {
+        let once = to_pg_text_form("foo\0bar\0baz").into_owned();
+        assert_eq!(once, "foobarbaz");
+        let twice = to_pg_text_form(&once).into_owned();
+        assert_eq!(twice, "foobarbaz");
+    }
+
+    #[test]
+    fn preserves_multi_byte_codepoints_around_nul() {
+        // Verifies the NUL strip doesn't slice across a UTF-8 codepoint
+        // boundary. "Csillagrablók" has multi-byte ó (0xC3 0xB3).
+        let out = to_pg_text_form("Csillagrabl\0ók");
+        assert_eq!(out, "Csillagrablók");
+        assert!(matches!(out, Cow::Owned(_)));
+    }
+
+    #[test]
+    fn preserves_non_nul_control_bytes() {
+        // Only U+0000 is stripped — other control bytes (tab, newline,
+        // VT, etc.) are valid TEXT values and pass through unchanged.
+        let input = "line1\tcol\nline2\x0bvt";
+        let out = to_pg_text_form(input);
+        assert_eq!(out, input);
+        assert!(matches!(out, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn cross_reference_to_text_forms_contract() {
+        // Sanity that to_pg_text_form does NOT do any normalization — case,
+        // diacritics, whitespace, ligatures all survive. Normalization is
+        // text::forms' job; this is a transport-safety helper.
+        let input = "  CAFÉ Tacvba  ";
+        let out = to_pg_text_form(input);
+        assert_eq!(out, input);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `wxyc_etl::pg::to_pg_text_form(s: &str) -> Cow<'_, str>` plus a PyO3 binding (`wxyc_etl.pg.to_pg_text_form` + `batch_to_pg_text_form`) that strips U+0000 (NUL) from strings before they reach a PostgreSQL TEXT column. NUL bytes are forbidden by the SQL standard in character types; today four consumers each carry their own one-line strip helper, and this PR centralizes the contract upstream.

## Why this is not a `text::forms` extension

The existing charter (`to_storage_form` / `to_match_form` / `to_ascii_form`) is about **normalization** — making strings comparable, deduplicatable, ASCII-foldable. `to_pg_text_form` is about **transport / boundary safety** — making strings *acceptable* to a downstream sink without changing their meaning. Different concern; mixing them under `text::forms` would blur a line carefully guarded since WX-2.

Lives in `wxyc-etl/src/pg/text.rs`, re-exported via `pg/mod.rs`, sitting next to the other PG-side concerns (`admin`, `batch`, `copy`, `dedup`). Module docstring states the boundary-vs-normalization line explicitly.

## Consumers this consolidates

WX-3.B landed strip-at-boundary in four consumer repos, each with its own one-line shape:

| Repo | Today's shape |
|---|---|
| WXYC/library-metadata-lookup | `_strip_nul(value: str \| None) -> str \| None` in `scripts/entity_resolution/store.py` |
| WXYC/musicbrainz-cache | inline `strip_nul(s: &str) -> Cow<'_, str>` in `src/import.rs` |
| WXYC/wikidata-cache | `'\0' => {}` arm inside `escape_copy_text` in `src/import.rs` |
| WXYC/discogs-etl | `strip_pg_null_bytes(s)` + 14 unit tests in `lib/pg_text.py` |

Follow-up cross-repo-migration ticket to sweep them onto `wxyc_etl::pg::to_pg_text_form` will be filed after 0.7.0 ships.

## Release coordination

No version bump in this PR — bundled with [#96](https://github.com/WXYC/wxyc-etl/issues/96) (deletion of the deprecated normalizer surface) into a coordinated 0.6.0 → 0.7.0 release. PR ordering:

1. PR [#139](https://github.com/WXYC/wxyc-etl/pull/139) (#96 deletion) — no bump
2. This PR (#104 helper add) — no bump
3. Bump PR: workspace `0.6.0 → 0.7.0`, tag `v0.7.0`

## Test plan

Local CI on this worktree:

- [x] `cargo fmt --check` (clean)
- [x] `cargo test -p wxyc-etl` — 481 lib + 13 integration test binaries pass (was 470, +11 pg::text tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings -A ...` (CI flags) — clean
- [x] `maturin build --release` (succeeded)
- [x] `pytest wxyc-etl-python/tests/` — 475 passed (was 469, +6 test_pg.py tests), 1 skipped, 3 deselected
- [x] `python tests/test_wheel_lifecycle.py --skip-build` — 42/42 smoke tests pass

Rust test coverage (`pg::text::tests`): empty / no-NUL Borrowed / single-NUL Owned / leading NUL / trailing NUL / all-NUL / idempotence on clean input / idempotence on NUL-bearing input / multi-byte codepoint boundary / non-NUL control byte passthrough / no-normalization sanity.

Python test coverage (`tests/test_pg.py`): parametric matrix over the same inputs + `to_pg_text_form(None) == \"\"` + batch parity vs single + empty / all-clean batches.

Closes #104