### PR TITLE
chore: bump workspace version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3133,7 +3133,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wxyc-etl"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "wxyc-etl-python"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,6 @@ members = ["wxyc-etl", "wxyc-etl-python"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps the workspace version from 0.6.0 → 0.7.0 to cut the coordinated WX-4.1 release.

This release bundles two breaking changes that landed together:

- **[#139](https://github.com/WXYC/wxyc-etl/pull/139)** (closes [#96](https://github.com/WXYC/wxyc-etl/issues/96)) — removes the deprecated `normalize_artist_name` / `strip_diacritics` / `normalize_title` / `batch_normalize` surface (both Rust and PyO3) after the full one-cycle grace period since 0.2.0.
- **[#140](https://github.com/WXYC/wxyc-etl/pull/140)** (closes [#104](https://github.com/WXYC/wxyc-etl/issues/104)) — adds `wxyc_etl::pg::to_pg_text_form(s: &str) -> Cow<'_, str>` plus the PyO3 binding `wxyc_etl.pg.to_pg_text_form` for stripping U+0000 before PG TEXT writes (WX-3.B policy consolidation).

## What ships

Per [`docs/releases.md`](https://github.com/WXYC/wxyc-etl/blob/main/docs/releases.md), once this PR merges and `v0.7.0` is tagged on the resulting commit, `release.yml` will:

1. Publish `wxyc-etl` to crates.io
2. Publish `wxyc-etl-python` to PyPI (abi3 wheels for x86_64/aarch64 linux + macos + sdist)
3. Build, smoke-test, and push `ghcr.io/wxyc/wxyc-postgres:pg17` / `:pg16` (floating) and `:pg17-v0.7.0` / `:pg16-v0.7.0` (pinned)

## Operator follow-up after release

- Coordinate Railway PG service swaps for the three cache repos (discogs-cache, musicbrainz-cache, wikidata-cache) per the wxyc-postgres image consumer contract in CLAUDE.md.
- Re-run the WX-1 corpus drift-guard across the 14-repo cascade per #96's acceptance criterion — any regression signals a consumer still on 0.1.x that we missed.

## Test plan

- [x] `cargo fmt --check` (clean)
- [x] `cargo test -p wxyc-etl` — 455 lib + 12 integration test binaries pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings -A ...` (CI flags) — clean
- [x] `Cargo.lock` regenerated with workspace bump to 0.7.0