### PR TITLE
feat(pg-python): preserve None in to_pg_text_form contract (0.8.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3133,7 +3133,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wxyc-etl"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "wxyc-etl-python"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,6 @@ members = ["wxyc-etl", "wxyc-etl-python"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"

--- a/wxyc-etl-python/src/pg.rs
+++ b/wxyc-etl-python/src/pg.rs
@@ -10,21 +10,26 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
 /// Make `s` acceptable for storage in a PostgreSQL TEXT column.
 ///
 /// Strips U+0000 (NUL) bytes, which the SQL standard forbids in character
-/// types. Accepts None (returns "") so Python callers don't need to guard
-/// NULL values from DB columns or optional API fields.
+/// types. `None` passes through as `None` so callers writing through
+/// `COALESCE(EXCLUDED.col, table.col)` upserts (or psycopg's COPY `\N`
+/// sentinel) continue to skip absent fields rather than overwriting them
+/// with the empty string.
 ///
 /// See WX-3.B / WXYC/docs#18 for the strip-at-boundary policy.
 #[pyfunction]
-fn to_pg_text_form(s: Option<&str>) -> String {
+fn to_pg_text_form(s: Option<&str>) -> Option<String> {
     s.map(|s| wxyc_etl::pg::to_pg_text_form(s).into_owned())
-        .unwrap_or_default()
 }
 
 /// Apply [`to_pg_text_form`] to each input in one cross-FFI call.
+///
+/// Each element is treated independently: `None` entries pass through as
+/// `None`, `str` entries get the NUL strip. The output list is the same
+/// length as the input.
 #[pyfunction]
-fn batch_to_pg_text_form(items: Vec<String>) -> Vec<String> {
+fn batch_to_pg_text_form(items: Vec<Option<String>>) -> Vec<Option<String>> {
     items
-        .iter()
-        .map(|s| wxyc_etl::pg::to_pg_text_form(s).into_owned())
+        .into_iter()
+        .map(|opt| opt.map(|s| wxyc_etl::pg::to_pg_text_form(&s).into_owned()))
         .collect()
 }

--- a/wxyc-etl-python/tests/test_pg.py
+++ b/wxyc-etl-python/tests/test_pg.py
@@ -33,9 +33,11 @@ def test_to_pg_text_form(input_str, expected):
     assert pg.to_pg_text_form(input_str) == expected
 
 
-def test_to_pg_text_form_accepts_none():
-    """Mirrors the charter-form Option<&str> -> "" contract."""
-    assert pg.to_pg_text_form(None) == ""
+def test_to_pg_text_form_preserves_none():
+    """Option<&str> -> Option<String>: None passes through unchanged so
+    COALESCE-based upserts in consumer repos continue to skip absent
+    fields rather than overwriting them with the empty string."""
+    assert pg.to_pg_text_form(None) is None
 
 
 def test_to_pg_text_form_idempotent():
@@ -52,8 +54,21 @@ def test_batch_to_pg_text_form_matches_singles():
     assert pg.batch_to_pg_text_form(inputs) == expected
 
 
+def test_batch_to_pg_text_form_preserves_none():
+    """Per-element None passes through unchanged, mirroring the singular
+    contract: callers can pass a heterogeneous list of `str | None` and
+    rely on positional None pass-through for downstream COALESCE writes."""
+    inputs = ["Stereolab", None, "Cat\0Power", None, "\0Autechre"]
+    expected = ["Stereolab", None, "CatPower", None, "Autechre"]
+    assert pg.batch_to_pg_text_form(inputs) == expected
+
+
 def test_batch_to_pg_text_form_empty():
     assert pg.batch_to_pg_text_form([]) == []
+
+
+def test_batch_to_pg_text_form_all_none():
+    assert pg.batch_to_pg_text_form([None, None, None]) == [None, None, None]
 
 
 def test_batch_to_pg_text_form_all_clean():


### PR DESCRIPTION
## Summary

Step 1 (PRECONDITION) of [#142](https://github.com/WXYC/wxyc-etl/issues/142) (WX-3.B follow-up consumer sweep). Changes the PyO3 binding so `None` passes through unchanged instead of being coerced to `""`:

- `to_pg_text_form(s: Option<&str>) -> Option<String>`
- `batch_to_pg_text_form(items: Vec<Option<String>>) -> Vec<Option<String>>`

The Rust crate API at `wxyc_etl::pg::to_pg_text_form` is unchanged — only the PyO3 wrapper signature moves.

## Why the contract has to change

The verification pass in [#142](https://github.com/WXYC/wxyc-etl/issues/142) surfaced that the 0.7.0 `None -> ""` coercion is incompatible with both Python consumers' load-bearing `None`-preserving helpers:

- **library-metadata-lookup** — `entity/store.py`'s `_UPSERT_IDENTITY_SQL` uses `COALESCE(EXCLUDED.col, entity.identity.col)` on every external ID column (`wikidata_qid`, `musicbrainz_artist_id`, `spotify_artist_id`, `apple_music_artist_id`, `bandcamp_id`). Migrating to `to_pg_text_form` under the 0.7.0 contract would clobber every previously-stored ID on any upsert that omits one — `COALESCE('', existing)` returns `''`, not `existing`. Data-corruption-grade silent break.
- **discogs-etl** — `scripts/import_csv.py` maps sentinel empty strings to `None` before writing through psycopg's `COPY ... FROM STDIN`, which needs `None` pass-through to emit `\N` (SQL `NULL`) instead of `''` for absent fields.

Both `library-metadata-lookup/entity/store.py:_strip_nul` and `discogs-etl/lib/pg_text.py:strip_pg_null_bytes` are explicitly `None`-preserving today, and the WX-1 charset-torture detector (which covers NUL handling) does not catch the `''`-vs-`NULL` distinction.

## What changed

- `wxyc-etl-python/src/pg.rs` — both `#[pyfunction]` signatures updated. Docstring rewritten to explain why `None` passes through.
- `wxyc-etl-python/tests/test_pg.py` — `test_to_pg_text_form_accepts_none` (asserting `None == \"\"`) replaced with `test_to_pg_text_form_preserves_none` (asserting `pg.to_pg_text_form(None) is None`); added `test_batch_to_pg_text_form_preserves_none` and `test_batch_to_pg_text_form_all_none` for the batch contract.
- `Cargo.toml` — workspace version bumped to `0.8.0` (the Rust crate API is unchanged, but `workspace.package.version` is single-valued, so the wxyc-etl crate atomically bumps too).

## What did NOT change

- `wxyc_etl::pg::to_pg_text_form` in the Rust crate (still `&str -> Cow<'_, str>`).
- Rust crate consumers (musicbrainz-cache, wikidata-cache) — the Rust API is the same, so their PRs can land in parallel with this one rather than after it.

## Test plan

- [x] `cargo check -p wxyc-etl-python` clean
- [x] `cargo test -p wxyc-etl` — 67 pg tests pass, full suite green
- [x] `maturin develop --release` builds the wheel
- [x] `pytest wxyc-etl-python/tests/test_pg.py -v` — 18/18 pass including the three new None-preservation cases
- [x] Full Python suite green: 241 passed, 1 skipped
- [x] `cargo clippy --workspace --all-targets` clean under the CI allow-list

## Rollout order (from [#142](https://github.com/WXYC/wxyc-etl/issues/142))

1. This PR merges → tag `v0.8.0` → release.yml publishes wheel to PyPI + crate to crates.io.
2. In parallel: musicbrainz-cache PR + wikidata-cache PR (Rust contract unchanged, can ship independently of step 1).
3. After PyPI publish: LML PR + discogs-etl PR consume the new `Option<String>` return and migrate their call-sites.

Towards [#142](https://github.com/WXYC/wxyc-etl/issues/142).